### PR TITLE
fixed prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ By default react-native-config will read from `.env`, but you can change it when
 To pick which file to use in Android, just set `ENVFILE` before building/running your app. For instance:
 
 ```
-$ ENVFILE=.env.staging react-native run-android
+$ env ENVFILE=.env.staging react-native run-android
 ```
 
 #### iOS


### PR DESCRIPTION
Got the error:

`Unsupported use of '='. To run 'react-native' with a modified environment, please use 'env ENVFILE=.env.staging react-native…'`