### PR TITLE
Added support for iOS access

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,16 @@ And use them to configure libraries in `AndroidManifest.xml` and others:
 
 ### iOS
 
-Xcode support is missing; variables declared in `.env`. can be consumed from React Native apps in iOS via `Config`, but not from `plist` files.
+Xcode support is missing; variables declared in `.env`. Can not be used from `plist` files, but in JS (via `Config`) or native Objective-C code like this:
+
+```Objective-C
+#import "ReactNativeConfig.h"
+
+...
+
+NSDictionary *config = [ReactNativeConfig constantsToExport];
+NSString password = config[@"RELEASE_STORE_PASSWORD"]
+```
 
 
 ### Different environments

--- a/ios/ReactNativeConfig/ReactNativeConfig.h
+++ b/ios/ReactNativeConfig/ReactNativeConfig.h
@@ -1,4 +1,5 @@
 #import "RCTBridgeModule.h"
 
 @interface ReactNativeConfig : NSObject <RCTBridgeModule>
++ (NSDictionary *) constantsToExport;
 @end

--- a/ios/ReactNativeConfig/ReactNativeConfig.m
+++ b/ios/ReactNativeConfig/ReactNativeConfig.m
@@ -5,6 +5,12 @@
 
 RCT_EXPORT_MODULE()
 
++ (NSDictionary *) constantsToExport {
+
+    return DOT_ENV
+
+}
+
 - (NSDictionary *)constantsToExport {
 
     return DOT_ENV


### PR DESCRIPTION
Hi there,

First of all thanks for this great tool, it really solves the environment problem in React Native.
I had the issue that I needed to access the contents of a variable in the `AppDelegate.m` for initialization (of OneSignal to be specific), so I added the option to access it through class methods.

I hope it works for you; I am relatively new to iOS development, so I don't know if I missed a bad practice here.

Regards ;)