### PR TITLE
Replace `%` with a double-escaped unicode value

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -16,8 +16,9 @@ readDotEnv()
 android {
     defaultConfig {
         project.env.each { k, v ->
+            def escaped = v.replaceAll("%","\\\\u0025")
             buildConfigField "String", k, "\"$v\""
-            resValue "string", k, "\"$v\""
+            resValue "string", k, "\"$escaped\""
         }
     }
 }


### PR DESCRIPTION
Android resource strings cannot include `%` as-is (cf. http://stackoverflow.com/questions/4414389/android-xml-percent-symbol).