### PR TITLE
Fix missing env

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -2,11 +2,17 @@ def readDotEnv = {
     def env = [:]
     def envFile = System.env['ENVFILE'] ?: ".env"
     println("Reading env from: $envFile")
-    new File("$project.rootDir/../$envFile").eachLine { line ->
-        def (key, val) = line.tokenize('=')
-        if (key && val && key.substring(0, 1) != "#") {
-            env.put(key, val)
-        }
+    try {
+      new File("$project.rootDir/../$envFile").eachLine { line ->
+          def (key, val) = line.tokenize('=')
+          if (key && val && key.substring(0, 1) != "#") {
+              env.put(key, val)
+          }
+      }
+    } catch (Exception ex) {
+      println("**************************")
+      println("*** Missing .env file ****")
+      println("**************************")
     }
     project.ext.set("env", env)
 }

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -18,7 +18,7 @@ puts "Reading env from #{file}"
 dotenv = File.read(File.join(Dir.pwd, "../../../#{file}")).split("\n").inject({}) do |h, line|
   key, val = line.split("=", 2)
   h.merge!(key => val)
-end
+end rescue {}
 
 # create obj file that sets DOT_ENV as a NSDictionary
 dotenv_objc = dotenv.map { |k, v| %Q(@"#{k}":@"#{v}") }.join(",")


### PR DESCRIPTION
Prevents missing `.env` files from breaking both iOS & Android.

This is happening in our [Ignite project](https://github.com/infinitered/ignite) which is a boilerplate for React Native.  We want `.env` to live in `.gitignore` which means, we'd have to write a script to automatically generate this file.

Which is problematic because it wouldn't run on `git pull`.

Related:

https://github.com/luggit/react-native-config/issues/7
