### PR TITLE
allow '=' character in env-variable value

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -6,7 +6,7 @@ def readDotEnv = {
       new File("$project.rootDir/../$envFile").eachLine { line ->
           def splitAt = line.indexOf("=")
           def key = line.substring(0, splitAt)
-          def value = line.substring(splitAt + 1, line.size())
+          def val = line.substring(splitAt + 1, line.size())
           if (key && val && key.substring(0, 1) != "#") {
               env.put(key, val)
           }

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -4,9 +4,9 @@ def readDotEnv = {
     println("Reading env from: $envFile")
     try {
       new File("$project.rootDir/../$envFile").eachLine { line ->
-          def splitted = line.tokenize('=')
-          def key = splitted[0]
-          def val = splitted.subList(1, splitted.size()).join('=')
+          def splitAt = a.indexOf("=")
+          def key = a.substring(0, splitAt)
+          def value = a.substring(splitAt + 1, a.size())
           if (key && val && key.substring(0, 1) != "#") {
               env.put(key, val)
           }

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -4,7 +4,9 @@ def readDotEnv = {
     println("Reading env from: $envFile")
     try {
       new File("$project.rootDir/../$envFile").eachLine { line ->
-          def (key, val) = line.tokenize('=')
+          def splitted = line.tokenize('=')
+          def key = splitted[0]
+          def val = splitted.subList(1, splitted.size()).join('=')
           if (key && val && key.substring(0, 1) != "#") {
               env.put(key, val)
           }

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -4,9 +4,9 @@ def readDotEnv = {
     println("Reading env from: $envFile")
     try {
       new File("$project.rootDir/../$envFile").eachLine { line ->
-          def splitAt = a.indexOf("=")
-          def key = a.substring(0, splitAt)
-          def value = a.substring(splitAt + 1, a.size())
+          def splitAt = line.indexOf("=")
+          def key = line.substring(0, splitAt)
+          def value = line.substring(splitAt + 1, line.size())
           if (key && val && key.substring(0, 1) != "#") {
               env.put(key, val)
           }


### PR DESCRIPTION
I ran into a situation where I had to store a string containing an `=` character in the value, and the string is terminated before the `=`:

```
VALUE=hello=world
```

would result in value being `hello`
