### PR TITLE
Support Archive operation 

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -41,6 +41,9 @@ EOF
 # write it so that ReactNativeConfig.m can return it
 path = File.join(ENV["SYMROOT"], "GeneratedDotEnv.m")
 File.open(path, "w") { |f| f.puts template }
+# for archive 
+path = File.join(Dir.pwd, "GeneratedDotEnv.m")
+File.open(path, "w") { |f| f.puts template }
 
 if custom_env
   File.delete("/tmp/envfile")


### PR DESCRIPTION
It seems for me that SYMROOT doesn't work in Archive, app just don't see this file for some reason and always use `.env`. This quick fix solved the issue. 

Or maybe I'm wrong. Have you tried to archive an app with react-native-config?
