### PR TITLE
Add support for multiple env files

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,18 +1,20 @@
 def readDotEnv = {
     def env = [:]
-    def envFile = System.env['ENVFILE'] ?: ".env"
-    println("Reading env from: $envFile")
+    def envFiles = System.env['ENVFILE'] ? System.env['ENVFILE'].split(',') : [".env"]
     try {
-      new File("$project.rootDir/../$envFile").eachLine { line ->
-          def (key, val) = line.tokenize('=')
-          if (key && val && key.substring(0, 1) != "#") {
-              env.put(key, val)
-          }
-      }
+        for (String envFile: envFiles) {
+            println("Reading env from: $envFile")
+            new File("$project.rootDir/../$envFile").eachLine { line ->
+                def (key, val) = line.tokenize('=')
+                if (key && val && key.substring(0, 1) != "#") {
+                    env.put(key, val)
+                }
+            }
+        }
     } catch (Exception ex) {
-      println("**************************")
-      println("*** Missing .env file ****")
-      println("**************************")
+        println("**************************")
+        println("*** Missing .env file ****")
+        println("**************************")
     }
     project.ext.set("env", env)
 }


### PR DESCRIPTION
Hi

We want to share some variables between the different environments and not repeat them (e.g. `VERSION`). 

This PR treats `ENVFILE` as a comma delimited list of paths so we can specify `EVNFILE=common,dev react-native run-android` etc. 

I've looked into the iOS implementation but seems it assumes a single `.env` file or a single `/tmp/envfile`, i.e. there is `ENVFILE`. 

Would love your feedback, especially for iOS