### PR TITLE
Add support for specifying custom env files in gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,19 @@ By default react-native-config will read from `.env`, but you can change it when
 
 #### Android
 
-To pick which file to use in Android, just set `ENVFILE` before building/running your app. For instance:
+To pick which file to use in Android, set a variable in your `build.config` before the `apply from:`:
+
+```
+project.ext.envConfigFiles = [
+    debug: ".env.development",
+    release: ".env.production",
+    anyCustomBuildTypeName: ".env",
+]
+
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
+```
+
+Alternatively, you can set `ENVFILE` before building/running your app. For instance:
 
 ```
 $ ENVFILE=.env.staging react-native run-android

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,6 +1,31 @@
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+def getCurrentFlavor() {
+    Gradle gradle = getGradle()
+    String tskReqStr = gradle.getStartParameter().getTaskRequests()[0].args
+
+    Matcher matcher = Pattern.compile("([A-Z]\\w+)").matcher( tskReqStr )
+    if( matcher.find() ) {
+        return matcher.group(1).toLowerCase()
+    } else {
+        return "";
+    }
+}
+
 def readDotEnv = {
+    def envFile = ".env"
+
+    if (System.env['ENVFILE']) {
+      envFile = System.env['ENVFILE'];
+    } else if (project.hasProperty("envConfigFiles")) {
+      def possibleFile = project.envConfigFiles.get(getCurrentFlavor())
+      if (possibleFile) {
+        envFile = possibleFile;
+      }
+    }
+
     def env = [:]
-    def envFile = System.env['ENVFILE'] ?: ".env"
     println("Reading env from: $envFile")
     try {
       new File("$project.rootDir/../$envFile").eachLine { line ->


### PR DESCRIPTION
Allows specifying the env files (when using different env files based on versions) in the build.gradle instead of needing to export an environment variable.  The advantage is that it only requires a change in the build.gradle instead of every place that calls ./gradlew install.  It still supports the environment variable approach to preserve compatibility.

Example usage in a `build.gradle`:
```
project.ext.envConfigFiles = [
    debug: ".env.development",
    release: ".env.production",
]

apply from: "../../node_modules/react-native/react.gradle"
apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
```
Note: it's important that it is before the `apply from: `