### PR TITLE
[info.plist] Add support for using constants in the Info.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Read variables in your Info.plist by appending `__RN_CONFIG_` to the name:
 ```
 __RN_CONFIG_API_URL
 ```
-Note: Requires specific setup (see below)
+Note: Requires specific setup (see below) and a `Product > Clean` is required after changing the values to see the updated values.
 
 
 ### Different environments

--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ NSString *apiUrl = [ReactNativeConfig envFor:@"API_URL"];
 NSDictionary *config = [ReactNativeConfig env];
 ```
 
-Support for `plist` files is missing. We'd love to be able to refer to config from `.env` there, but haven't found a way to support this yet. Let us know if you have ideas!
+Read variables in your Info.plist by appending `__RN_CONFIG_` to the name:
+
+```
+__RN_CONFIG_API_URL
+```
+Note: Requires specific setup (see below)
 
 
 ### Different environments
@@ -126,6 +131,14 @@ Link the library:
 ```
 $ react-native link react-native-config
 ```
+
+### Extra step for iOS to support Info.plist
+
+* Go to your project -> Build Settings -> All
+* Search for "preprocess" 
+* Set `Preprocess Info.plist File` to `Yes`
+* Set `Info.plist Preprocessor Prefix File` to `${CONFIGURATION_BUILD_DIR}/GeneratedInfoPlistDotEnv.h`
+* If you don't see those settings, verify that "All" is selected at the top (instead of "Basic")
 
 ### Extra step for Android
 

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -42,6 +42,13 @@ EOF
 path = File.join(ENV["SYMROOT"], "GeneratedDotEnv.m")
 File.open(path, "w") { |f| f.puts template }
 
+# create header file with defines for the Info.plist preprocessor
+info_plist_defines_objc = dotenv.map { |k, v| %Q(#define __RN_CONFIG_#{k}  #{v}) }.join("\n")
+
+# write it so the Info.plist preprocessor can access it
+path = File.join(ENV["CONFIGURATION_BUILD_DIR"], "GeneratedInfoPlistDotEnv.h")
+File.open(path, "w") { |f| f.puts info_plist_defines_objc }
+
 if custom_env
   File.delete("/tmp/envfile")
 end


### PR DESCRIPTION
Add the ability to use config in the `Info.plist` file.  

Based on https://coderwall.com/p/euesdq/use-defined-values-in-info-plist