### PR TITLE
Default export to empty object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,4 +5,4 @@
 // iOS: config vars set in xcconfig and exposed via ReactNativeConfig.m
 import { NativeModules } from 'react-native';
 
-export default NativeModules.ReactNativeConfig;
+export default NativeModules.ReactNativeConfig || {};


### PR DESCRIPTION
If `.env` file is empty/non-existant this module will export `null` instead of as expected an empty object. That will crash apps using the way suggested in the docs; `Config.SOME_VAR`. In my app I want it to run with defaults straight from the source and then be able to override some values via the .env file. 