### PR TITLE
Clarify that must use lowercase build names

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ By default react-native-config will read from `.env`, but you can change it when
 
 #### Android
 
-To pick which file to use in Android, set a variable in your `build.config` before the `apply from:`:
+To pick which file to use in Android, set a variable in your `build.config` before the `apply from:` using all lowercase names:
 
 ```
 project.ext.envConfigFiles = [
     debug: ".env.development",
     release: ".env.production",
-    anyCustomBuildTypeName: ".env",
+    anycustombuildlowercase: ".env",
 ]
 
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"


### PR DESCRIPTION
Clarify that build names must be lowercase when specifying the env file in build.gradle.

Right now it does a comparison between the map specified in `build.gradle` and a lowercase version of the task that is run (example: `./gradlew installStagingRelease` would be "stagingrelease" which it would search for as the key in the map).  Alternatively we could a case-insensitive compare, but it requires re-creating the hashmap (with all lowercase keys) as there is no easy way to do a case-insensitive get() on a HashMap(). 