### PR TITLE
[android] Add ability to build with multiple .env files at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ project.ext.envConfigFiles = [
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 ```
 
+When doing this you can no longer use `project.env.get("APP_ID")` since it is possible to build multiple versions at once.  Instead in your build.gradle use `project.env_{build_type}.get("APP_ID")` (example: `project.env_release.get("APP_ID")`).
+
+If you want to use a constant for all the builds types you can do the following before your existing `android` section in the `build.gradle`.
+
+```
+android.buildTypes.all { type ->
+    def envFile = "env_" + type.name;
+    type.applicationId = project.ext.get(envFile).get("APP_ID");
+}
+
+android {
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
+    ...
+}
+```
+
 Alternatively, you can set `ENVFILE` before building/running your app. For instance:
 
 ```

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,55 +1,63 @@
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-def getCurrentFlavor() {
-    Gradle gradle = getGradle()
-    String tskReqStr = gradle.getStartParameter().getTaskRequests()[0].args
-
-    Matcher matcher = Pattern.compile("([A-Z]\\w+)").matcher( tskReqStr )
-    if( matcher.find() ) {
-        return matcher.group(1).toLowerCase()
-    } else {
-        return "";
+def readFile = { envFile ->
+  def env = [:]
+  println("Reading env from: $envFile")
+  try {
+    new File("$project.rootDir/../$envFile").eachLine { line ->
+        def (key, val) = line.tokenize('=')
+        if (key && val && key.substring(0, 1) != "#") {
+            env.put(key, val)
+        }
     }
+  } catch (Exception ex) {
+    println("**************************")
+    println("*** Missing .env file ****")
+    println("**************************")
+  }
+  return env;
 }
 
 def readDotEnv = {
-    def envFile = ".env"
-
     if (System.env['ENVFILE']) {
-      envFile = System.env['ENVFILE'];
+        project.ext.set("env", readFile(System.env['ENVFILE']))
     } else if (project.hasProperty("envConfigFiles")) {
-      def possibleFile = project.envConfigFiles.get(getCurrentFlavor())
-      if (possibleFile) {
-        envFile = possibleFile;
-      }
+        for (Map.Entry<String, String> entry : project.envConfigFiles.entrySet()) {
+            def buildType = entry.getKey();
+            def envFile = entry.getValue();
+            project.ext.set("env_$buildType", readFile(envFile))
+        }
+    } else {
+        project.ext.set("env", readFile(".env"))
     }
-
-    def env = [:]
-    println("Reading env from: $envFile")
-    try {
-      new File("$project.rootDir/../$envFile").eachLine { line ->
-          def (key, val) = line.tokenize('=')
-          if (key && val && key.substring(0, 1) != "#") {
-              env.put(key, val)
-          }
-      }
-    } catch (Exception ex) {
-      println("**************************")
-      println("*** Missing .env file ****")
-      println("**************************")
-    }
-    project.ext.set("env", env)
 }
 
 readDotEnv()
 
-android {
-    defaultConfig {
-        project.env.each { k, v ->
-            def escaped = v.replaceAll("%","\\\\u0025")
-            buildConfigField "String", k, "\"$v\""
-            resValue "string", k, "\"$escaped\""
-        }
+// Sets the constants at project.env_{build_type_name} when doing multiple builds (and therefore using multiple config files)
+// Example: project.env_Release.get("APP_ID") in build.gradle
+android.buildTypes.all { type ->
+    def envFile = "env_" + type.name;
+    if (project.ext.has(envFile)) {
+      project.ext.get(envFile).each { k, v ->
+          def escaped = v.replaceAll("%","\\\\u0025")
+          buildConfigField "String", k, "\"$v\""
+          resValue "string", k, "\"$escaped\""
+      }
     }
+}
+
+// Sets the constants at project.env when using only one config file
+// Example: project.env.get("APP_ID") in build.gradle
+if (project.ext.has("env")) {
+  android {
+      defaultConfig {
+          project.ext.get("env").each { k, v ->
+              def escaped = v.replaceAll("%","\\\\u0025")
+              buildConfigField "String", k, "\"$v\""
+              resValue "string", k, "\"$escaped\""
+          }
+      }
+  }
 }


### PR DESCRIPTION
This extends upon https://github.com/luggit/react-native-config/pull/52.  In that one it determines the correct .env file based on the task that is running (for example: `./gradlew installDebug` would map to a debug env file).

Unfortunately it doesn't work when doing multiple builds at once.  Example: `./gradlew assemble` which assembles all the build types.  This PR allows it to work in that case.

It's a bit more complicated to use, since we are using all the .env files at once in this case.  Because of that we can't just use `project.env` in the build.gradle.

I've preserved backwards compatibility for the case of specifying the .env via the ENVFILE environment variable, as well as using the default (".env").  In those cases, it is still possible to use `project.env.get("APP_ID")` in the build.gradle.

In the case of specifying the .env files within the `build.gradle` (added in #52), it no longer works with `project.env.get("APP_ID")` and must use the new syntax (which is detailed in the README).

It is a bit more complicated to setup, but works better overall.  Let me know what you think.

### Test Plan:
Works with environment variable
```
$ ENVFILE=.env.development ./gradlew installDebug
Reading env from: .env.development
```
Works with default file
```
$ ./gradlew installDebug
Reading env from: .env
```
Works with multiple build types (although we are only building debug, it still reads all the .env files)
```
$ ./gradlew installDebug
Reading env from: .env.development
Reading env from: .env.staging
Reading env from: .env.production
```