### PR TITLE
Support For Multi Target Applications

### DIFF
--- a/Example/ios/Example.xcodeproj/project.pbxproj
+++ b/Example/ios/Example.xcodeproj/project.pbxproj
@@ -829,7 +829,7 @@
 					"$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig",
 				);
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
-				INFOPLIST_PREFIX_HEADER = "${CONFIGURATION_BUILD_DIR}/GeneratedInfoPlistDotEnv.h";
+				INFOPLIST_PREFIX_HEADER = "${BUILD_DIR}/GeneratedInfoPlistDotEnv.h";
 				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -873,7 +873,7 @@
 					"$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig",
 				);
 				INFOPLIST_OTHER_PREPROCESSOR_FLAGS = "-traditional";
-				INFOPLIST_PREFIX_HEADER = "${CONFIGURATION_BUILD_DIR}/GeneratedInfoPlistDotEnv.h";
+				INFOPLIST_PREFIX_HEADER = "${BUILD_DIR}/GeneratedInfoPlistDotEnv.h";
 				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $ react-native link react-native-config
 * Go to your project -> Build Settings -> All
 * Search for "preprocess" 
 * Set `Preprocess Info.plist File` to `Yes`
-* Set `Info.plist Preprocessor Prefix File` to `${CONFIGURATION_BUILD_DIR}/GeneratedInfoPlistDotEnv.h`
+* Set `Info.plist Preprocessor Prefix File` to `${BUILD_DIR}/GeneratedInfoPlistDotEnv.h`
 * Set `Info.plist Other Preprocessor Flags` to `-traditional`
 * If you don't see those settings, verify that "All" is selected at the top (instead of "Basic")
 

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -46,7 +46,7 @@ File.open(path, "w") { |f| f.puts template }
 info_plist_defines_objc = dotenv.map { |k, v| %Q(#define __RN_CONFIG_#{k}  #{v}) }.join("\n")
 
 # write it so the Info.plist preprocessor can access it
-path = File.join(ENV["CONFIGURATION_BUILD_DIR"], "GeneratedInfoPlistDotEnv.h")
+path = File.join(ENV["BUILD_DIR"], "GeneratedInfoPlistDotEnv.h")
 File.open(path, "w") { |f| f.puts info_plist_defines_objc }
 
 if custom_env

--- a/ios/ReactNativeConfig/ReactNativeConfig.h
+++ b/ios/ReactNativeConfig/ReactNativeConfig.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface ReactNativeConfig : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Hi!

I needed to ammend this: CONFIGURATION_BUILD_DIR => BUILD_DIR

in order to support multitargetApplications in ios. The CONFIGURATION_BUILD_DIR resolves to:

build/Debug-iphoneos/GeneratedInfoPlistDotEnv.h

but imagine you have a watch app watch extenstion and ios today widget in other targets. They will for example resolve to:

build/Debug-watchos/GeneratedInfoPlistDotEnv.h

which produces build errors, this pr fixes that