### PR TITLE
Add input file to run script to fix build problems on server

### DIFF
--- a/ios/ReactNativeConfig.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeConfig.xcodeproj/project.pbxproj
@@ -138,12 +138,13 @@
 			files = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/ReactNativeConfig/BuildDotenvConfig.ruby",
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./ReactNativeConfig/BuildDotenvConfig.ruby";
+			shellScript = ./ReactNativeConfig/BuildDotenvConfig.ruby;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/ReactNativeConfig/ReactNativeConfig.h
+++ b/ios/ReactNativeConfig/ReactNativeConfig.h
@@ -1,4 +1,8 @@
+#if __has_include("RCTBridgeModule.h")
+#import "RCTBridgeModule.h"
+#else
 #import <React/RCTBridgeModule.h>
+#endif
 
 @interface ReactNativeConfig : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Hi, thanks for the great module!

It works fine when building in Xcode myself, but when running Xcode build on my build server, it will fail because it does not find the included Ruby-script.

This is fixed by adding the ruby script as an input file in the build phase run script.