### PR TITLE
Fix RCTBridgeModule import

### DIFF
--- a/ios/ReactNativeConfig/ReactNativeConfig.h
+++ b/ios/ReactNativeConfig/ReactNativeConfig.h
@@ -1,4 +1,4 @@
-#import <React/RCTBridgeModule.h>
+#import "RCTBridgeModule.h"
 
 @interface ReactNativeConfig : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
This fixes an Xcode error where the file cannot be found.

react native version: 0.40.0