### PR TITLE
Support Dotenv with quotes and nested quotes

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -20,6 +20,7 @@ dotenv = begin
   raw = File.read(File.join(Dir.pwd, "../../../#{file}"))
   raw.split("\n").inject({}) do |h, line|
     m = line.match(dotenv_pattern)
+    next h if m.nil?
     key = m[:key]
     # Ensure string (in case of empty value) and escape any quotes present in the value.
     val = m[:val].to_s.gsub('"', '\"')

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -15,13 +15,14 @@ puts "Reading env from #{file}"
 
 dotenv = begin
   # https://regex101.com/r/SLdbes/1
-  dotenv_pattern = /^(?<key>[[:upper:]_]+)=(?<quote>["'])(?<val>.*?[^\\])\k<quote>$/
+  dotenv_pattern = /^(?<key>[[:upper:]_]+)=((?<quote>["'])(?<val>.*?[^\\])\k<quote>|)$/
   # find that above node_modules/react-native-config/ios/
   raw = File.read(File.join(Dir.pwd, "../../../#{file}"))
   raw.split("\n").inject({}) do |h, line|
     m = line.match(dotenv_pattern)
     key = m[:key]
-    val = m[:val].gsub('"', '\"')
+    # Ensure string (in case of empty value) and escape any quotes present in the value.
+    val = m[:val].to_s.gsub('"', '\"')
     h.merge(key => val)
   end
 rescue Errno::ENOENT

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -14,16 +14,15 @@ end
 puts "Reading env from #{file}"
 
 dotenv = begin
+  # https://regex101.com/r/SLdbes/1
+  dotenv_pattern = /^(?<key>[[:upper:]_]+)=(?<quote>["'])(?<val>.*?[^\\])\k<quote>$/
   # find that above node_modules/react-native-config/ios/
   raw = File.read(File.join(Dir.pwd, "../../../#{file}"))
   raw.split("\n").inject({}) do |h, line|
-    key, val = line.split("=", 2)
-    if line.strip.empty? or line.start_with?('#')
-      h
-    else
-      key, val = line.split("=", 2)
-      h.merge!(key => val)
-    end
+    m = line.match(dotenv_pattern)
+    key = m[:key]
+    val = m[:val].gsub('"', '\"')
+    h.merge(key => val)
   end
 rescue Errno::ENOENT
   puts("**************************")


### PR DESCRIPTION
Addressing #97 

When parsing dotenv files, if there's any guide to follow, it's the defacto [npm dotenv project](https://www.npmjs.com/package/dotenv#rules)

> The parsing engine currently supports the following rules:

> * BASIC=basic becomes {BASIC: 'basic'}
> * empty lines are skipped
> * lines beginning with # are treated as comments
> * empty values become empty strings (EMPTY= becomes {EMPTY: ''})
> * single and double quoted values are escaped (SINGLE_QUOTE='quoted' becomes {SINGLE_QUOTE: "quoted"})
> * new lines are expanded if in double quotes (MULTILINE="new\nline" becomes
{MULTILINE: 'new
line'}
> * inner quotes are maintained (think JSON) (JSON={"foo": "bar"} becomes {JSON:"{\"foo\": \"bar\"}")

This PR implements a more sophisticated matching using a [regular expression](https://regex101.com/r/SLdbes/1). This allows the parser to handle all the cases presented in the dotenv node package.