### PR TITLE
Package: including .podspec file during package installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "android/",
     "ios/",
-    "index.js"
+    "index.js",
+    "react-native-config.podspec"
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
We are not able to install package via Cocoapods at the moment. The .podspec file is part of the code in repository, but it's not installed with package via `npm` or `yarn`