### PR TITLE
Change dotenv pattern to support lowercase and numbers.

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -15,7 +15,7 @@ puts "Reading env from #{file}"
 
 dotenv = begin
   # https://regex101.com/r/SLdbes/1
-  dotenv_pattern = /^(?<key>[[:upper:]_]+)=((?<quote>["'])?(?<val>.*?[^\\])\k<quote>?|)$/
+  dotenv_pattern = /^(?<key>[[:alnum:]_]+)=((?<quote>["'])?(?<val>.*?[^\\])\k<quote>?|)$/
   # find that above node_modules/react-native-config/ios/
   raw = File.read(File.join(Dir.pwd, "../../../#{file}"))
   raw.split("\n").inject({}) do |h, line|


### PR DESCRIPTION
With support of quotes in 0.4.1, the ruby regex only supports uppercase alphabetic characters.  While lowercase characters are non-standard for ENV variables, they should still be supported.  Numbers obviously should, ex. 'M2_HOME=...'.