### PR TITLE
Use .properties files instead of .env files

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
 require "json"
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
 
 # pick a custom env file if set
 if File.exists?("/tmp/envfile")

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -49,7 +49,7 @@ File.open(path, "w") { |f| f.puts template }
 info_plist_defines_objc = dotenv.map { |k, v| %Q(#define __RN_CONFIG_#{k}  #{v}) }.join("\n")
 
 # write it so the Info.plist preprocessor can access it
-path = File.join(ENV["BUILD_DIR"], "GeneratedInfoPlistDotEnv.h")
+path = File.join(ENV["CONFIGURATION_BUILD_DIR"], "GeneratedInfoPlistDotEnv.h")
 File.open(path, "w") { |f| f.puts info_plist_defines_objc }
 
 if custom_env


### PR DESCRIPTION
[#85](https://github.com/luggit/react-native-config/issues/85)
I've tested it on android and iOS. It can now handle any UTF-8 character. It should probably do a lot more to be fully compatible with .properties files 
[.properties](https://en.wikipedia.org/wiki/.properties)
