### PR TITLE
Allow exported variables in .env

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -33,7 +33,7 @@ def readDotEnv = {
     println("Reading env from: $envFile")
     try {
         new File("$project.rootDir/../$envFile").eachLine { line ->
-            def matcher = (line =~ /^\s*([\w\d\.\-_]+)\s*=\s*(.*)?\s*$/)
+            def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*)?['"]?\s*$/)
             if (matcher.getCount() == 1 && matcher[0].size() == 3){
                 env.put(matcher[0][1], matcher[0][2])
             }

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -14,8 +14,8 @@ end
 puts "Reading env from #{file}"
 
 dotenv = begin
-  # https://regex101.com/r/SLdbes/1
-  dotenv_pattern = /^(?<key>[[:alnum:]_]+)=((?<quote>["'])?(?<val>.*?[^\\])\k<quote>?|)$/
+  # https://regex101.com/r/aFZMSB
+  dotenv_pattern = /^(?:export\s+|)(?<key>[[:alnum:]_]+)=((?<quote>["'])?(?<val>.*?[^\\])\k<quote>?|)$/
   # find that above node_modules/react-native-config/ios/
   raw = File.read(File.join(Dir.pwd, "../../../#{file}"))
   raw.split("\n").inject({}) do |h, line|


### PR DESCRIPTION
Being able to export variables in a `.env` file allows one to be able to source the file in bash scripts, which can be immensely helpful.  I've updated the regex to also check for an optional unmatched group `export\s+`.

I also added a bit of regex to remove quotes for android - I'm sure that regex could be better, but I needed something like it and it worked for me.

Lastly I updated the regex101 link in `ios/ReactNativeConfig/BuildDotenvConfig.ruby`