### PR TITLE
Allow to specify env files location as absolute path

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -44,18 +44,25 @@ def readDotEnv = {
 
     def env = [:]
     println("Reading env from: $envFile")
-    try {
-        new File("$project.rootDir/../$envFile").eachLine { line ->
-            def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*)?['"]?\s*$/)
-            if (matcher.getCount() == 1 && matcher[0].size() == 3){
-                env.put(matcher[0][1], matcher[0][2])
-            }
-        }
-    } catch (FileNotFoundException ignored) {
+
+    File f = new File("$project.rootDir/../$envFile");
+    if (!f.exists()) {
+      f = new File("$envFile");
+    }
+
+    if (f.exists()) {
+      f.eachLine { line ->
+          def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*)?['"]?\s*$/)
+          if (matcher.getCount() == 1 && matcher[0].size() == 3){
+              env.put(matcher[0][1], matcher[0][2])
+          }
+      }
+    } else {
         println("**************************")
         println("*** Missing .env file ****")
         println("**************************")
     }
+
     project.ext.set("env", env)
 }
 

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -16,8 +16,14 @@ puts "Reading env from #{file}"
 dotenv = begin
   # https://regex101.com/r/aFZMSB
   dotenv_pattern = /^(?:export\s+|)(?<key>[[:alnum:]_]+)=((?<quote>["'])?(?<val>.*?[^\\])\k<quote>?|)$/
+
   # find that above node_modules/react-native-config/ios/
-  raw = File.read(File.join(Dir.pwd, "../../../#{file}"))
+  path = File.join(Dir.pwd, "../../../#{file}")
+  if !File.exists?(path)
+    # try as absolute path
+    path = file
+  end
+  raw = File.read(path)
   raw.split("\n").inject({}) do |h, line|
     m = line.match(dotenv_pattern)
     next h if m.nil?


### PR DESCRIPTION
Allow to specify an absolute path for the configuration files for different environments. If envFile is not found try to load it as absolute path. 