### PR TITLE
ReactNative 0.47.0 - Android Breaking change - Remove override of 'createJSModules'

### DIFF
--- a/android/src/main/java/com/lugg/ReactNativeConfig/ReactNativeConfigPackage.java
+++ b/android/src/main/java/com/lugg/ReactNativeConfig/ReactNativeConfigPackage.java
@@ -19,11 +19,6 @@ public class ReactNativeConfigPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
As of ReactNative version 0.47.0 a breaking (Android) change was introduced where it is no longer necessary to override 'createJSModules'.

See details [here](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8).