### PR TITLE
Add Pods Public Header path to HEADER_SEARCH_PATHS

### DIFF
--- a/ios/ReactNativeConfig.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeConfig.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
 					"${SYMROOT}",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -259,6 +260,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
 					"${SYMROOT}",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
When react-native is installed using cocoapods xcode cannot find react headers for react-native-config. This PR adds to HEADER_SEARCH_PATHS to look at header files in the Pods. 
Since Cocoapods does not allow build scripts it's still a good idea to link react-native-config with react-native link and add support for projects that do use react native via cocoapods