### PR TITLE
Update regex examples to clarify treatment of spaces

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -14,7 +14,7 @@ end
 puts "Reading env from #{file}"
 
 dotenv = begin
-  # https://regex101.com/r/aFZMSB
+  # https://regex101.com/r/cbm5Tp/1
   dotenv_pattern = /^(?:export\s+|)(?<key>[[:alnum:]_]+)=((?<quote>["'])?(?<val>.*?[^\\])\k<quote>?|)$/
   # find that above node_modules/react-native-config/ios/
   raw = File.read(File.join(Dir.pwd, "../../../#{file}"))


### PR DESCRIPTION
Found the treatment of whitespace a bit interesting, wasn't sure if it was intentional, but wanted to document it!

```
# Double quotes contain the resulting values (to signify whitespace)
DOT_ENV=dotenv # => "dotenv"
#DOTENV=dotenv # => no match
DOT_ENV= asdf asf # => " asdf asf "
DOTENV='dot env' # => "dot env"
DOTENV="dot env" # => "dot env"
DOT_ENV='dotenv' # => "dotenv"
DOT_ENV="DotEnv" # => "DotEnv"
DOTENV="Dot\nEnv" # => "Dot\nEnv"
DOTENV="{"Dot":"Env"}" # => "{\"Dot\":\"Env\"}"
export DOTENV="dotenv" # => "dotenv"
DOTENV ="dot env" # => no match
DOTENV= "dot env" # => "dot env"
DOTENV = "dot env" # => no match
```