### PR TITLE
fixed Android dotenv.gradle quotes matching

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -46,7 +46,7 @@ def readDotEnv = {
     println("Reading env from: $envFile")
     try {
         new File("$project.rootDir/../$envFile").eachLine { line ->
-            def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*)?['"]?\s*$/)
+            def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)
             if (matcher.getCount() == 1 && matcher[0].size() == 3){
                 env.put(matcher[0][1], matcher[0][2])
             }


### PR DESCRIPTION
Fixed the regex - it caused syntax error in generated BuildConfig.java file when quotes were used in the `.env` file. `export VAR1="aa bb cc"` caused
```
/BuildConfig.java:15: error: unclosed string literal
  public static final String VAR1 = "aa bb cc"";
                                              ^
1 error
```