### PR TITLE
Change import priority of React/RCTBridgeModule.h

### DIFF
--- a/ios/ReactNativeConfig/ReactNativeConfig.h
+++ b/ios/ReactNativeConfig/ReactNativeConfig.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface ReactNativeConfig : NSObject <RCTBridgeModule>


### PR DESCRIPTION
Fixes redefinition of RCTMethodInfo in RN 0.48+