### PR TITLE
reverse priority of imports (to support React Native 0.48)

### DIFF
--- a/ios/ReactNativeConfig/ReactNativeConfig.h
+++ b/ios/ReactNativeConfig/ReactNativeConfig.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface ReactNativeConfig : NSObject <RCTBridgeModule>


### PR DESCRIPTION
In React Native 0.48 `#import "RCTBridgeModule.h"` resolves to an incorrect file, and thus makes the build fail. By reversing the imports the framework style import has priority, but still will be BC because older versions of RN do not have framework imports