### PR TITLE
Add `requiresMainQueueSetup` to fix warning in RN 0.49+

### DIFF
--- a/ios/ReactNativeConfig/ReactNativeConfig.m
+++ b/ios/ReactNativeConfig/ReactNativeConfig.m
@@ -5,6 +5,11 @@
 
 RCT_EXPORT_MODULE()
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 + (NSDictionary *)env {
     return (NSDictionary *)DOT_ENV;
 }


### PR DESCRIPTION
After upgrading to RN 0.49 I get the following warning:
```
Module ReactNativeConfig requires main queue setup since it overrides constantsToExport but doesn't implement requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```

This PR should fix that