### PR TITLE
Allow utf-8 character in config value

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 
+# Allow utf-8 charactor in config value
+# For example, APP_NAME=中文字符
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 # pick a custom env file if set
 if File.exists?("/tmp/envfile")
   custom_env = true


### PR DESCRIPTION
If i declare Chinese character become a value, when i run my app in xcode, it will fail and show the follow error message:
```
./ReactNativeConfig/BuildDotenvConfig.ruby:22:in `split': invalid byte sequence in US-ASCII (ArgumentError)
	from ./ReactNativeConfig/BuildDotenvConfig.ruby:22:in `<main>'
```

So i add this two lines code to avoid this error.

```ruby
Encoding.default_external = Encoding::UTF_8
Encoding.default_internal = Encoding::UTF_8
```

now it works fine.