### PR TITLE
dotenv.gradle: Set environment variables per variant buildConfig task, with .env fallback

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -44,13 +44,13 @@ def readDotEnv(currentFlavor) {
 
 tasks.whenTaskAdded { task ->
     if (project.hasProperty("envConfigFiles")) {
-        project.envConfigFiles.each { envKey, envValue ->
-            if (task.name.toLowerCase() == "generate"+envKey+"buildconfig") {
+        project.envConfigFiles.each { envConfigName, envConfigFile ->
+            if (task.name.toLowerCase() == "generate"+envConfigName+"buildconfig") {
                 task.doFirst() {
                     android.applicationVariants.all { variant ->
                         def variantConfigString = variant.getVariantData().getVariantConfiguration().getFullName()
-                        if (envKey.contains(variantConfigString.toLowerCase())) {
-                            readDotEnv(envKey)
+                        if (envConfigName.contains(variantConfigString.toLowerCase())) {
+                            readDotEnv(envConfigName)
                             project.env.each { k, v ->
                                 def escaped = v.replaceAll("%","\\\\u0025")
                                 variant.buildConfigField "String", k, "\"$v\""

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,79 +1,52 @@
-import java.util.regex.Matcher
-import java.util.regex.Pattern
-
-def getCurrentFlavor() {
-    Gradle gradle = getGradle()
-
-    // match optional modules followed by the task
-    // (?:.*:)* is a non-capturing group to skip any :foo:bar: if they exist
-    // *[a-z]+([A-Za-z]+) will capture the flavor part of the task name onward (e.g., assembleRelease --> Release)
-    def pattern = Pattern.compile("(?:.*:)*[a-z]+([A-Z][A-Za-z]+)")
-    def flavor = ""
-
-    gradle.getStartParameter().getTaskNames().any { name ->
-        Matcher matcher = pattern.matcher(name)
-        if (matcher.find()) {
-            flavor = matcher.group(1).toLowerCase()
-            return true
-        }
-    }
-
-    return flavor
-}
-
-def readDotEnv = {
+def readDotEnv(currentFlavor) {
     def envFile = ".env"
-
-    if (project.hasProperty("defaultEnvFile")) {
-        envFile = project.defaultEnvFile
-    }
 
     if (System.env['ENVFILE']) {
         envFile = System.env['ENVFILE'];
     } else if (project.hasProperty("envConfigFiles")) {
-        def flavor = getCurrentFlavor()
-
-        // use startsWith because sometimes the task is "generateDebugSources", so we want to match "debug"
-        project.ext.envConfigFiles.any { pair ->
-            if (flavor.startsWith(pair.key)) {
-                envFile = pair.value
-                return true
-            }
+        def possibleFile = project.envConfigFiles.get(currentFlavor)
+        if (possibleFile) {
+            envFile = possibleFile;
         }
     }
 
     def env = [:]
     println("Reading env from: $envFile")
-
-    File f = new File("$project.rootDir/../$envFile");
-    if (!f.exists()) {
-      f = new File("$envFile");
-    }
-
-    if (f.exists()) {
-        f.eachLine { line ->
-            def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)
-            if (matcher.getCount() == 1 && matcher[0].size() == 3) {
+    try {
+        new File("$project.rootDir/../$envFile").eachLine { line ->
+            def matcher = (line =~ /^\s*([\w\d\.\-_]+)\s*=\s*(.*)?\s*$/)
+            if (matcher.getCount() == 1 && matcher[0].size() == 3){
                 env.put(matcher[0][1], matcher[0][2])
             }
         }
-    } else {
+    } catch (FileNotFoundException ex) {
         println("**************************")
         println("*** Missing .env file ****")
         println("**************************")
     }
-
     project.ext.set("env", env)
 }
 
-readDotEnv()
+tasks.whenTaskAdded { task ->
+    if (project.hasProperty("envConfigFiles")) {
+        project.envConfigFiles.each { envKey, envValue ->
+            if (task.name.toLowerCase() == "generate"+envKey+"buildconfig") {
+                task.doFirst() {
+                    android.applicationVariants.all { variant ->
+                        def variantConfigString = variant.getVariantData().getVariantConfiguration().getFullName()
+                        if (envKey.contains(variantConfigString.toLowerCase())) {
+                            readDotEnv(envKey)
+                            project.env.each { k, v ->
+                                def escaped = v.replaceAll("%","\\\\u0025")
+                                variant.buildConfigField "String", k, "\"$v\""
+                                variant.resValue "string", k, "\"$escaped\""
+                            }
+                        }
+                    }
 
-android {
-    defaultConfig {
-        project.env.each { k, v ->
-            def escaped = v.replaceAll("%","\\\\u0025")
-            buildConfigField "String", k, "\"$v\""
-            resValue "string", k, "\"$escaped\""
+                }
+            }
         }
     }
 }
+

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,29 +1,44 @@
 def readDotEnv(currentFlavor) {
     def envFile = ".env"
 
+    if (project.hasProperty("defaultEnvFile")) {
+        envFile = project.defaultEnvFile
+    }
+
     if (System.env['ENVFILE']) {
         envFile = System.env['ENVFILE'];
     } else if (project.hasProperty("envConfigFiles")) {
-        def possibleFile = project.envConfigFiles.get(currentFlavor)
-        if (possibleFile) {
-            envFile = possibleFile;
+
+        // use startsWith because sometimes the task is "generateDebugSources", so we want to match "debug"
+        project.ext.envConfigFiles.any { pair ->
+            if (currentFlavor.startsWith(pair.key)) {
+                envFile = pair.value
+                return true
+            }
         }
     }
 
     def env = [:]
     println("Reading env from: $envFile")
-    try {
-        new File("$project.rootDir/../$envFile").eachLine { line ->
-            def matcher = (line =~ /^\s*([\w\d\.\-_]+)\s*=\s*(.*)?\s*$/)
-            if (matcher.getCount() == 1 && matcher[0].size() == 3){
+
+    File f = new File("$project.rootDir/../$envFile");
+    if (!f.exists()) {
+        f = new File("$envFile");
+    }
+
+    if (f.exists()) {
+        f.eachLine { line ->
+            def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)
+            if (matcher.getCount() == 1 && matcher[0].size() == 3) {
                 env.put(matcher[0][1], matcher[0][2])
             }
         }
-    } catch (FileNotFoundException ex) {
+    } else {
         println("**************************")
         println("*** Missing .env file ****")
         println("**************************")
     }
+
     project.ext.set("env", env)
 }
 
@@ -43,7 +58,6 @@ tasks.whenTaskAdded { task ->
                             }
                         }
                     }
-
                 }
             }
         }

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,4 +1,4 @@
-def readDotEnv(currentFlavor) {
+def loadDotEnv(currentFlavor) {
     def envFile = ".env"
 
     if (project.hasProperty("defaultEnvFile")) {
@@ -42,6 +42,18 @@ def readDotEnv(currentFlavor) {
     project.ext.set("env", env)
 }
 
+loadDotEnv('.env')
+
+android {
+    defaultConfig {
+        project.env.each { k, v ->
+            def escaped = v.replaceAll("%","\\\\u0025")
+            buildConfigField "String", k, "\"$v\""
+            resValue "string", k, "\"$escaped\""
+        }
+    }
+}
+
 tasks.whenTaskAdded { task ->
     if (project.hasProperty("envConfigFiles")) {
         project.envConfigFiles.each { envConfigName, envConfigFile ->
@@ -50,7 +62,7 @@ tasks.whenTaskAdded { task ->
                     android.applicationVariants.all { variant ->
                         def variantConfigString = variant.getVariantData().getVariantConfiguration().getFullName()
                         if (envConfigName.contains(variantConfigString.toLowerCase())) {
-                            readDotEnv(envConfigName)
+                            loadDotEnv(envConfigName)
                             project.env.each { k, v ->
                                 def escaped = v.replaceAll("%","\\\\u0025")
                                 variant.buildConfigField "String", k, "\"$v\""

--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -4,6 +4,7 @@
 if File.exists?("/tmp/envfile")
   custom_env = true
   file = File.read("/tmp/envfile").strip
+  defaultEnvFile = ".env"
 else
   custom_env = false
   file = ENV["ENVFILE"] || ".env"
@@ -22,6 +23,19 @@ dotenv = begin
     path = file
   end
   raw = File.read(path)
+
+  if (defaultEnvFile)
+    defaultEnvPath = File.join(Dir.pwd, "../../../#{defaultEnvFile}")
+    if !File.exists?(defaultEnvPath)
+      # try as absolute path
+      defaultEnvPath = defaultEnvFile
+    end
+    defaultRaw = File.read(defaultEnvPath)
+    if (defaultRaw)
+      raw = defaultRaw + "\n" + raw
+    end
+  end
+
   raw.split("\n").inject({}) do |h, line|
     m = line.match(dotenv_pattern)
     next h if m.nil?


### PR DESCRIPTION
This pull request is meant to address https://github.com/luggit/react-native-config/issues/135

In the case of utilizing this library with BuddyBuild, an **app:assemble** command will only set the environment variables once during the gradle build. This update will hook the task of setting the environment variable before a **generate buildConfig** task. This allows us to hook into each variant that is created in the project.