### PR TITLE
Updated Gradle version to work with Android Studio 2.3 and above

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
I was bringing this library into my project, and I noticed that the build tools version for Android is very much out of date. Android Studio 2.3.3 won't even build dependencies with this tool version. I went ahead and updated them to be compatible with Android Studio 2.3.3. (I'm actually on Android Studio 3.0, which is the most recent version, but I thought that might be too much of an upgrade.) Please let me know if there's a good reason not to upgrade the build tools.

As far as I can tell, the library works as expected after the build tools update, but I think it would be great if others could test this to make sure it works as expected.