### PR TITLE
Updated dotenv.gradle

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -7,6 +7,8 @@ def loadDotEnv(currentFlavor) {
 
     if (System.env['ENVFILE']) {
         envFile = System.env['ENVFILE'];
+    } else if (System.getProperty('ENVFILE')) {
+        envFile = System.getProperty('ENVFILE');
     } else if (project.hasProperty("envConfigFiles")) {
 
         // use startsWith because sometimes the task is "generateDebugSources", so we want to match "debug"


### PR DESCRIPTION
Added an option to check for the "ENVFILE" var in the System properties, simply to allow more flexibility when running react-native-config directly from android studio with flavors