### PR TITLE
Include ts definitions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "index.js",
     "react-native-config.podspec"
   ],
+  "types": "./index.d.ts",
   "license": "MIT"
 }


### PR DESCRIPTION
I saw that you have a small file with ts definitions. Would be great to have it included in package.json.