### PR TITLE
Enable typings for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Expose config variables to React Native apps",
   "keywords": ["env", "config", "config-var", "react-native", "android", "ios", "12factor"],
   "homepage": "https://github.com/luggit/react-native-config",
+  "types": "./index.d.ts",
   "contributors": [],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hey!

This PR added typings for TypeScript https://github.com/luggit/react-native-config/pull/186
but unfortunately didn't enable it in `package.json`. I've fixed it. 😉 

BR, Andrew.