### PR TITLE
Refactor dotenv.gradle functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-
+build/

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,8 +1,6 @@
 import java.util.regex.Matcher
 
 def getCurrentFlavorLowerCased() {
-    Gradle gradle = getGradle()
-
     // match optional modules followed by the task
     // (?:.*:)* is a non-capturing group to skip any :foo:bar: if they exist
     // *[a-z]+([A-Za-z]+) will capture the flavor part of the task name onward (e.g., assembleRelease --> Release)

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -21,7 +21,7 @@ def getCurrentFlavorLowerCased() {
     return flavor
 }
 
-def matchEnvFile(flavor) {
+def getEnvFilename(flavor) {
     if (System.env['ENVFILE']) {
         return System.env['ENVFILE']
     } else if (System.getProperty('ENVFILE')) {
@@ -39,14 +39,14 @@ def matchEnvFile(flavor) {
 }
 
 def loadDotEnv(flavor = getCurrentFlavorLowerCased()) {
-    def envFile = matchEnvFile(flavor)
+    def envFilename = getEnvFilename(flavor)
 
     def env = [:]
-    println("Reading env from: $envFile")
+    println("Reading env from: $envFilename")
 
-    File f = new File("$project.rootDir/../$envFile");
+    File f = new File("$project.rootDir/../$envFilename");
     if (!f.exists()) {
-        f = new File("$envFile");
+        f = new File("$envFilename");
     }
 
     if (f.exists()) {

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -22,10 +22,8 @@ def getCurrentFlavorLowerCased() {
 }
 
 def getEnvFilename(flavor) {
-    if (System.env['ENVFILE']) {
-        return System.env['ENVFILE']
-    } else if (System.getProperty('ENVFILE')) {
-        return System.getProperty('ENVFILE')
+    if (System.env['ENVFILE'] || System.getProperty('ENVFILE')) {
+        return System.env['ENVFILE'] ?: System.getProperty('ENVFILE')
     } else if (project.hasProperty("defaultEnvFile")) {
         return project.defaultEnvFile
     } else if (project.hasProperty("envConfigFiles")) {

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,5 +1,4 @@
 import java.util.regex.Matcher
-import java.util.regex.Pattern
 
 def getCurrentFlavorLowerCased() {
     Gradle gradle = getGradle()
@@ -7,11 +6,11 @@ def getCurrentFlavorLowerCased() {
     // match optional modules followed by the task
     // (?:.*:)* is a non-capturing group to skip any :foo:bar: if they exist
     // *[a-z]+([A-Za-z]+) will capture the flavor part of the task name onward (e.g., assembleRelease --> Release)
-    def pattern = Pattern.compile("(?:.*:)*[a-z]+([A-Z][A-Za-z]+)")
+    def pattern = /(?:.*:)*[a-z]+([A-Z][A-Za-z]+)/
     def flavor = ""
 
     gradle.getStartParameter().getTaskNames().any { name ->
-        Matcher matcher = pattern.matcher(name)
+        Matcher matcher = name =~ pattern
         if (matcher.find()) {
             flavor = matcher.group(1).toLowerCase()
             return true

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -58,9 +58,7 @@ def loadDotEnv(flavor = getCurrentFlavorLowerCased()) {
         f = new File("$envFilename");
     }
 
-    def env = getEnvVariableMap(f);
-
-    project.ext.set("env", env)
+    project.ext.set("env", getEnvVariableMap(f))
 }
 
 loadDotEnv()

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -30,9 +30,10 @@ def getEnvFilename(flavor) {
         return project.defaultEnvFile
     } else if (project.hasProperty("envConfigFiles")) {
         // use startsWith because sometimes the task is "generateDebugSources", so we want to match "debug"
-        return project.ext.envConfigFiles.find{pair -> 
+        def possibleConfig = project.ext.envConfigFiles.find{pair -> 
             flavor.startsWith(pair.key.toLowerCase())
-        }.value
+        }
+        return possibleConfig?.value ?: ".env"
     } else {
         return ".env";
     }

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -32,6 +32,23 @@ def getEnvFilename(flavor) {
     }
 }
 
+def getEnvVariableMap(file) {
+    if (file.exists()) {
+        return file.readLines().inject([:], { env, line ->
+            def matcher = line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/
+            if (matcher.getCount() == 1 && matcher[0].size() == 3) {
+                env.put(matcher[0][1], matcher[0][2].replace('"', '\\"'))
+            }
+            return env;
+        })
+    } else {
+        println("**************************")
+        println("*** Missing .env file ****")
+        println("**************************")
+        return [:]
+    }
+}
+
 def loadDotEnv(flavor = getCurrentFlavorLowerCased()) {
     def envFilename = getEnvFilename(flavor)
     println("Reading env from: $envFilename")
@@ -41,19 +58,7 @@ def loadDotEnv(flavor = getCurrentFlavorLowerCased()) {
         f = new File("$envFilename");
     }
 
-    def env = [:]
-    if (f.exists()) {
-        f.eachLine { line ->
-            def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)
-            if (matcher.getCount() == 1 && matcher[0].size() == 3) {
-                env.put(matcher[0][1], matcher[0][2].replace('"', '\\"'))
-            }
-        }
-    } else {
-        println("**************************")
-        println("*** Missing .env file ****")
-        println("**************************")
-    }
+    def env = getEnvVariableMap(f);
 
     project.ext.set("env", env)
 }

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,7 +1,7 @@
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-def getCurrentFlavor() {
+def getCurrentFlavorLowerCased() {
     Gradle gradle = getGradle()
 
     // match optional modules followed by the task
@@ -21,24 +21,25 @@ def getCurrentFlavor() {
     return flavor
 }
 
-def loadDotEnv(flavor = getCurrentFlavor()) {
-    def envFile = ".env"
-
+def matchEnvFile(flavor) {
     if (System.env['ENVFILE']) {
-        envFile = System.env['ENVFILE']
+        return System.env['ENVFILE']
     } else if (System.getProperty('ENVFILE')) {
-        envFile = System.getProperty('ENVFILE')
+        return System.getProperty('ENVFILE')
     } else if (project.hasProperty("defaultEnvFile")) {
-        envFile = project.defaultEnvFile
+        return project.defaultEnvFile
     } else if (project.hasProperty("envConfigFiles")) {
         // use startsWith because sometimes the task is "generateDebugSources", so we want to match "debug"
-        project.ext.envConfigFiles.any { pair ->
-            if (flavor.startsWith(pair.key)) {
-                envFile = pair.value
-                return true
-            }
-        }
+        return project.ext.envConfigFiles.find{pair -> 
+            flavor.startsWith(pair.key.toLowerCase())
+        }.value
+    } else {
+        return ".env";
     }
+}
+
+def loadDotEnv(flavor = getCurrentFlavorLowerCased()) {
+    def envFile = matchEnvFile(flavor)
 
     def env = [:]
     println("Reading env from: $envFile")

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -1,5 +1,3 @@
-import java.util.regex.Matcher
-
 def getCurrentFlavorLowerCased() {
     // match optional modules followed by the task
     // (?:.*:)* is a non-capturing group to skip any :foo:bar: if they exist
@@ -8,7 +6,7 @@ def getCurrentFlavorLowerCased() {
     def flavor = ""
 
     gradle.getStartParameter().getTaskNames().any { name ->
-        Matcher matcher = name =~ pattern
+        def matcher = name =~ pattern
         if (matcher.find()) {
             flavor = matcher.group(1).toLowerCase()
             return true

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -34,8 +34,6 @@ def getEnvFilename(flavor) {
 
 def loadDotEnv(flavor = getCurrentFlavorLowerCased()) {
     def envFilename = getEnvFilename(flavor)
-
-    def env = [:]
     println("Reading env from: $envFilename")
 
     File f = new File("$project.rootDir/../$envFilename");
@@ -43,6 +41,7 @@ def loadDotEnv(flavor = getCurrentFlavorLowerCased()) {
         f = new File("$envFilename");
     }
 
+    def env = [:]
     if (f.exists()) {
         f.eachLine { line ->
             def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)


### PR DESCRIPTION
I refactored the functions because I wanted to make them bit more clear :)
- env filename generation is now coming from `getEnvFilename` only
- renamed `getCurrentFlavor` to `getCurrentFlavorLowerCased ` to make function name more clear
- simplified `getCurrentFlavorLowerCased` function body

PS. Also noted that the comment `// *[a-z]+([A-Za-z]+) will capture the flavor part of the task name onward (e.g., assembleRelease --> Release)` does not match to regex `*[a-z]+([A-Z][A-Za-z]+)`. Can somebody tell me how to correct the comment? Or just remove the comment?