### PR TITLE
Correct readme instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The simplest approach is to tell it what file to read with an environment variab
 
 ```
 $ ENVFILE=.env.staging react-native run-ios           # bash
-$ SET ENVFILE='.env.staging' && react-native run-ios  # windows
+$ SET ENVFILE=.env.staging && react-native run-ios    # windows
 $ env:ENVFILE=".env.staging"; react-native run-ios    # powershell
 ```
 


### PR DESCRIPTION
In order to get it to work on Windows, you need to not surround the ENVFILE variable with quotes. See issue #211 (thanks @SandraLum !)