### PR TITLE
set `file` to /tmp/envfile path instead of content

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -10,7 +10,7 @@ defaultEnvFile = ".env"
 # pick a custom env file if set
 if File.exists?("/tmp/envfile")
   custom_env = true
-  file = File.read("/tmp/envfile").strip
+  file = "/tmp/envfile"
 else
   custom_env = false
   file = ENV["ENVFILE"] || defaultEnvFile


### PR DESCRIPTION
Fixes #219.

Seems that in Xcode `BuildDotenvConfig.ruby` is not correctly reading the contents of `/tmp/envfile` if available. I've traced the problem down to the line 13.

```
  file = File.read("/tmp/envfile").strip
```

`file` contains the content of `/tmp/envfile` which the script then attempts to append to `path` and reading starting at line 26.

The problem can be solved by changing line 13 to simply be the path, which is then correctly read in and processed.

```
file = "/tmp/envfile"
```