### PR TITLE
Rearrange Readme so Setup steps are clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Module to expose config variables to your javascript code in React Native, suppo
 Bring some [12 factor](http://12factor.net/config) love to your mobile apps!
 
 
-## Usage
+## Basic Usage
 
 Create a new file `.env` in the root of your React Native app:
 
@@ -25,6 +25,55 @@ Config.GOOGLE_MAPS_API_KEY  // 'abcdefgh'
 
 Keep in mind this module doesn't obfuscate or encrypt secrets for packaging, so **do not store sensitive keys in `.env`**. It's [basically impossible to prevent users from reverse engineering mobile app secrets](https://rammic.github.io/2015/07/28/hiding-secrets-in-android-apps/), so design your app (and APIs) with that in mind.
 
+
+## Setup
+
+Install the package:
+
+```
+$ yarn add react-native-config
+```
+
+Link the library:
+
+```
+$ react-native link react-native-config
+```
+
+
+### Extra step for Android
+
+You'll also need to manually apply a plugin to your app, from `android/app/build.gradle`:
+
+```
+// 2nd line, add a new apply:
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
+```
+
+
+### Extra step for iOS (support Info.plist)
+
+* Go to your project -> Build Settings -> All
+* Search for "preprocess"
+* Set `Preprocess Info.plist File` to `Yes`
+* Set `Info.plist Preprocessor Prefix File` to `${BUILD_DIR}/GeneratedInfoPlistDotEnv.h`
+* Set `Info.plist Other Preprocessor Flags` to `-traditional`
+* If you don't see those settings, verify that "All" is selected at the top (instead of "Basic")
+
+
+#### Advanced Android Setup
+
+In `android/app/build.gradle`, if you use `applicationIdSuffix` or `applicationId` that is different from the package name indicated in `AndroidManifest.xml` in `<manifest package="...">` tag, for example, to support different build variants:
+Add this in `android/app/build.gradle`
+
+```
+defaultConfig {
+    ...
+    resValue "string", "build_config_package", "YOUR_PACKAGE_NAME_IN_ANDROIDMANIFEST.XML"
+}
+```
+
+## Native Usage
 
 ### Android
 
@@ -143,54 +192,6 @@ Then edit the newly created scheme to make it use a different env file. From the
   ```
 
 This is still a bit experimental and dirty – let us know if you have a better idea on how to make iOS use different configurations opening a pull request or issue!
-
-
-## Setup
-
-Install the package:
-
-```
-$ yarn add react-native-config
-```
-
-Link the library:
-
-```
-$ react-native link react-native-config
-```
-
-
-### Extra step for Android
-
-You'll also need to manually apply a plugin to your app, from `android/app/build.gradle`:
-
-```
-// 2nd line, add a new apply:
-apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
-```
-
-
-### Extra step for iOS to support Info.plist
-
-* Go to your project -> Build Settings -> All
-* Search for "preprocess"
-* Set `Preprocess Info.plist File` to `Yes`
-* Set `Info.plist Preprocessor Prefix File` to `${BUILD_DIR}/GeneratedInfoPlistDotEnv.h`
-* Set `Info.plist Other Preprocessor Flags` to `-traditional`
-* If you don't see those settings, verify that "All" is selected at the top (instead of "Basic")
-
-
-#### Advanced Android Setup
-
-In `android/app/build.gradle`, if you use `applicationIdSuffix` or `applicationId` that is different from the package name indicated in `AndroidManifest.xml` in `<manifest package="...">` tag, for example, to support different build variants:
-Add this in `android/app/build.gradle`
-
-```
-defaultConfig {
-    ...
-    resValue "string", "build_config_package", "YOUR_PACKAGE_NAME_IN_ANDROIDMANIFEST.XML"
-}
-```
 
 ## Troubleshooting
 


### PR DESCRIPTION
After my experience setting up this library, I strongly recommend these changes.

1. Move Setup info close to the top so it's clear what's necessary.  From the current description, it appears that just importing the library is sufficient, since the reader is probably trying to read from the top and follow step-by-step.

2. Make it clearer that the .plist step is necessary

Thanks!