### PR TITLE
Added rudimentary system environment variable support.

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -52,7 +52,7 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
         f.eachLine { line ->
             def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)
             if (matcher.getCount() == 1 && matcher[0].size() == 3) {
-                env.put(matcher[0][1], matcher[0][2].replace('"', '\\"'))
+                env.put(matcher[0][1], System.env[matcher[0][1]] || matcher[0][2].replace('"', '\\"'))
             }
         }
     } else {

--- a/ios/ReactNativeConfig/ReactNativeConfig.m
+++ b/ios/ReactNativeConfig/ReactNativeConfig.m
@@ -15,6 +15,8 @@ RCT_EXPORT_MODULE()
 }
 
 + (NSString *)envFor: (NSString *)key {
+    NSString *envValue = (NSString *)[[[NSProcessInfo processInfo]environment]objectForKey:key];
+    if (envValue) return envValue;
     NSString *value = (NSString *)[self.env objectForKey:key];
     return value;
 }


### PR DESCRIPTION
**Note:** This is WIP and I definitely need some help on making this work the way most people would expect.

## Summary

To really follow 12-factor, we need to be able to use environment variables at compile-time. I think what I have might just work on android, since it's in the gradle file, and iOS might just need to be documented, but I'd really like some other eyes of people who are way smarter than me.

Related to my issue, #271 

## Tasks

 - [x] Adds checks to grab variables out of env before grabbing them from the file.
 - [ ] Adds before-build script for android to write a gradle file (?) that reads the build env variables and maps them to the correct keys. (**Note:** Is this needed?)
 - [ ] Document iOS process, as [described in this SO post](https://stackoverflow.com/a/28099597/661764) to copy compile-time environment variables. Is there a way to automatically do this?
 - [ ] Test?