### PR TITLE
Update build.gradle to remove compile warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+' // from node_modules
+    implementation 'com.facebook.react:react-native:+' // from node_modules
 }


### PR DESCRIPTION
With the latest react-native version RN >= 0.57 the android build tools were updated and now using `compile` in the build.gradle file generates the following error:
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html