### PR TITLE
Update README on how to install with CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,35 @@ apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.grad
 * Search for "preprocess"
 * Set `Preprocess Info.plist File` to `Yes`
 * Set `Info.plist Preprocessor Prefix File` to `${BUILD_DIR}/GeneratedInfoPlistDotEnv.h`
+
+  **Cocoapods**
+
+  If you are using **CocoaPods** in your project, set to `$(SRCROOT)/../node_modules/react-native-config/ios/ReactNativeConfig/GeneratedInfoPlistDotEnv.h` 
+
+  Update your `Podfile` add the following line in the dependencies list:
+
+  `pod 'react-native-config', :path => '../node_modules/react-native-config'`
+
+  Finally add the following at the end of your `Podfile` 
+
+  ```ruby
+  post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      if target.name == 'react-native-config'
+        phase = target.project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
+        phase.shell_script = "cd ../../"\
+                             " && RNC_ROOT=./node_modules/react-native-config/"\
+                             " && export SYMROOT=$RNC_ROOT/ios/ReactNativeConfig"\
+                             " && export BUILD_DIR=$RNC_ROOT/ios/ReactNativeConfig"\
+                             " && ruby $RNC_ROOT/ios/ReactNativeConfig/BuildDotenvConfig.ruby"
+  
+        target.build_phases << phase
+        target.build_phases.move(phase,0)
+      end
+    end
+  end
+  ```
+
 * Set `Info.plist Other Preprocessor Flags` to `-traditional`
 * If you don't see those settings, verify that "All" is selected at the top (instead of "Basic")
 
@@ -200,7 +229,6 @@ This is still a bit experimental and dirty – let us know if you have a better
 When Proguard is enabled (which it is by default for Android release builds), it can rename the `BuildConfig` Java class in the minification process and prevent React Native Config from referencing it. To avoid this, add an exception to `android/app/proguard-rules.pro`:
 
     -keep class com.mypackage.BuildConfig { *; }
-    
 `mypackage` should match the `package` value in your `app/src/main/AndroidManifest.xml` file.
 
 ## Testing


### PR DESCRIPTION
After spending some time figuring out how this package can work in my project while using CocoaPods, I've found a working solution from the [comment](https://github.com/luggit/react-native-config/issues/125#issuecomment-436872749) of the issue #125 

This PR updates the guide on how to install this package if you are using CocoaPods(for iOS). This solves the issue faced by CocoaPods user when they try to run the app after installing this package, like issue #125.

Thanks to @clarsen for the comment on the issue.

