### PR TITLE
always set default value instead of .env

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -22,8 +22,8 @@ def getCurrentFlavor() {
 }
 
 def loadDotEnv(flavor = getCurrentFlavor()) {
-    def envFile = ".env"
 
+    def envFile = project.hasProperty("defaultEnvFile") ? project.defaultEnvFile : ".env"
     if (System.env['ENVFILE']) {
         envFile = System.env['ENVFILE']
     } else if (System.getProperty('ENVFILE')) {
@@ -36,8 +36,6 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
                 return true
             }
         }
-    } else if (project.hasProperty("defaultEnvFile")) {
-        envFile = project.defaultEnvFile
     }
 
     def env = [:]


### PR DESCRIPTION
Closes #327

This is one solution using defalutEnvFile to avoid mismatching env setting by not included build variant string if the other task about build task calling dotenv.gradle. check #327.