### PR TITLE
Resolving '//' in xcconfig values so that urls can be used

### DIFF
--- a/ios/ReactNativeConfig/BuildXCConfig.rb
+++ b/ios/ReactNativeConfig/BuildXCConfig.rb
@@ -9,5 +9,5 @@ puts "reading env file from #{envs_root} and writing .config to #{config_output}
 
 dotenv, custom_env = read_dot_env(envs_root)
 
-dotenv_xcconfig = dotenv.map { |k, v| %(#{k}=#{v}) }.join("\n")
+dotenv_xcconfig = dotenv.map { |k, v| %(#{k}=#{v.gsub(/\/\//, "/$()/")}) }.join("\n")
 File.open(config_output, 'w') { |f| f.puts dotenv_xcconfig }


### PR DESCRIPTION
The problem is that `//` are treated as comments in a xcconfig file.
As a consequence, any config values that are urls like `https://google.com` will be interpreted as `https:` by xcode from the xcconfig file. 
This PR solves it by inserting an empty variable `$()` between the double slashes `//` ([see this stack Q&A](https://stackoverflow.com/questions/21317844/how-do-i-configure-full-urls-in-xcconfig-files)). The regex replace is done in `BuildXCConfig.rb`

Best regards,
  Derk

