### PR TITLE
Fix flavor matching in dotenv.gradle

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -31,7 +31,7 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
     } else if (project.hasProperty("envConfigFiles")) {
         // use startsWith because sometimes the task is "generateDebugSources", so we want to match "debug"
         project.ext.envConfigFiles.any { pair ->
-            if (flavor.startsWith(pair.key)) {
+            if (flavor.startsWith(pair.key.toLowerCase())) {
                 envFile = pair.value
                 return true
             }


### PR DESCRIPTION
`getCurrentFlavor` is returning flavor in lower case but `loadDotEnv` just compare flavor with the key in `envConfigFiles` directly

Example:
If the flavor named as `tempRelease`, `getCurrentFlavor` will return `temprelease` and the comparison will be failed