### PR TITLE
Set iOS deployment target to 9.0

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/luggit/react-native-config'
 
   s.license      = 'MIT'
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
 
   s.source       = { git: 'https://github.com/luggit/react-native-config.git', tag: "v#{s.version.to_s}" }


### PR DESCRIPTION
This removes a warning in Xcode that it's targeting below the minimum version. Also [React Native supports iOS 9.0 and above](https://github.com/facebook/react-native#-requirements).