### PR TITLE
Update Podspec version

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
 
-  s.source       = { git: 'https://github.com/luggit/react-native-config.git', tag: s.version.to_s }
+  s.source       = { git: 'https://github.com/luggit/react-native-config.git', tag: "v#{s.version}" }
   s.script_phase = {
     name: 'Config codegen',
     script: %(


### PR DESCRIPTION
Now when you do `pod install` cocoapods tries to clone tag 0.11.7 but the tags are v0.11.7. I updated the podspec to used the correct tag that adds a `v`.

This fixes the following error:

```
[!] Error installing react-native-config
[!] /usr/bin/git clone https://github.com/luggit/react-native-config.git /var/folders/tj/8qdrhkns4ml4r6j9mpy92y6w0000gn/T/d20190918-39540-1ioq1kg --template= --single-branch --depth 1 --branch 0.11.7

Cloning into '/var/folders/tj/8qdrhkns4ml4r6j9mpy92y6w0000gn/T/d20190918-39540-1ioq1kg'...
warning: Could not find remote branch 0.11.7 to clone.
fatal: Remote branch 0.11.7 not found in upstream origin
```