### PR TITLE
Support spaces in iOS .env file

### DIFF
--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -22,7 +22,7 @@ def read_dot_env(envs_root)
 
   dotenv = begin
     # https://regex101.com/r/cbm5Tp/1
-    dotenv_pattern = /^(?:export\s+|)(?<key>[[:alnum:]_]+)=((?<quote>["'])?(?<val>.*?[^\\])\k<quote>?|)$/
+    dotenv_pattern = /^(?:export\s+|)(?<key>[[:alnum:]_]+)\s*=\s*((?<quote>["'])?(?<val>.*?[^\\])\k<quote>?|)$/
 
     path = File.expand_path(File.join(envs_root, file.to_s))
     if File.exist?(path)


### PR DESCRIPTION
Fix to allow spaces in .env file