### PR TITLE
Remove delete of envfile

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.rb
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.rb
@@ -25,6 +25,6 @@ EOF
 path = File.join(m_output_path, 'GeneratedDotEnv.m')
 File.open(path, 'w') { |f| f.puts template }
 
-File.delete('/tmp/envfile') if custom_env
+#File.delete('/tmp/envfile') if custom_env
 
 puts "Wrote to #{path}"


### PR DESCRIPTION
This should be ok as subsequent runs just overwrite that file anyhow...
closes https://github.com/bars0um/react-native-config/issues/1

Otherwise a race condition occurs / or possibly just an odd state where a second execution of the task during the same build finds no envfile 