### PR TITLE
Update docs to include Dexguard keep resource rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ When Proguard is enabled (which it is by default for Android release builds), it
 
 `com.mypackage` should match the `package` value in your `app/src/main/AndroidManifest.xml` file.
 
+If using Dexguard, the shrinking phase will remove resources it thinks are unused. It is necessary to add an exception to preserve the build config package name.
+
+    -keepresources string/build_config_package
+
 ## Testing
 
 Since `react-native-config` contains native code, it cannot be run in a node.js environment (Jest, Mocha). [react-native-config-node](https://github.com/CureApp/react-native-config-node) provides a way to mock `react-native-config` for use in test runners - exactly as it is used in the actual app.


### PR DESCRIPTION
We started integrating Dexguard into our project and were noticing the build config was coming through empty. In addition to the existing ProGuard rule, it is necessary to preserve the resource representing the build config package name.