### PR TITLE
Fix incorrect default env path on iOS

### DIFF
--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -30,13 +30,12 @@ def read_dot_env(envs_root)
     elsif File.exist?(file)
       raw = File.read(file)
     else
-      defaultEnvPath = File.expand_path(File.join(envs_root, "../#{defaultEnvFile}"))
+      defaultEnvPath = File.expand_path(File.join(envs_root, "#{defaultEnvFile}"))
       unless File.exist?(defaultEnvPath)
         # try as absolute path
         defaultEnvPath = defaultEnvFile
       end
-      defaultRaw = File.read(defaultEnvPath)
-      raw = defaultRaw + "\n" + raw if defaultRaw
+      raw = File.read(defaultEnvPath)
     end
 
     raw.split("\n").inject({}) do |h, line|


### PR DESCRIPTION
When `/tmp/envfile` points to a file that does not exist, it was not possible to load the default .env file because `defaultEnvPath` was pointing to the parent directory of `envs_root`. Also, I'm not a Ruby developer so please correct me if I am wrong, but I think line 39 is useless since `raw` will never be defined defined at that point.