### PR TITLE
[ios] App extensions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 
 node_modules
 xcuserdata
-xcshareddata

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 
 node_modules
+xcuserdata
+xcshareddata

--- a/README.md
+++ b/README.md
@@ -187,6 +187,18 @@ ios/tmp.xcconfig
 "${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb" "${SRCROOT}/.." "${SRCROOT}/tmp.xcconfig"
 ```
 
+#### App Extensions
+
+Add dependency to `react-native-config`.
+
+```
+target 'ShareExtension' do
+  platform :ios, '9.0'
+
+  pod 'react-native-config', :path => '../node_modules/react-native-config'
+end
+```
+
 ### Different environments
 
 Save config for different environments in different files: `.env.staging`, `.env.production`, etc.

--- a/android/src/main/java/com/lugg/ReactNativeConfig/ReactNativeConfigModule.java
+++ b/android/src/main/java/com/lugg/ReactNativeConfig/ReactNativeConfigModule.java
@@ -20,7 +20,7 @@ public class ReactNativeConfigModule extends ReactContextBaseJavaModule {
 
   @Override
   public String getName() {
-    return "ReactNativeConfig";
+    return "ReactNativeConfigModule";
   }
 
   @Override

--- a/index.js
+++ b/index.js
@@ -5,4 +5,4 @@
 // iOS: config vars set in xcconfig and exposed via ReactNativeConfig.m
 import { NativeModules } from 'react-native';
 
-export default NativeModules.ReactNativeConfig || {};
+export default NativeModules.ReactNativeConfigModule || {};

--- a/ios/ReactNativeConfig.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeConfig.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07BF4DBD2476FBED00E59829 /* ReactNativeConfigModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 07BF4DBC2476FBED00E59829 /* ReactNativeConfigModule.m */; };
 		3DF7F6B6203AA0C200D0EAB7 /* ReactNativeConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = EBE4E8461C7D2456000F8875 /* ReactNativeConfig.m */; };
 		3DF7F6B7203AA0D600D0EAB7 /* ReactNativeConfig.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = EB2648E21C7BE17A00B8F155 /* ReactNativeConfig.h */; };
 		EB2648E31C7BE17A00B8F155 /* ReactNativeConfig.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = EB2648E21C7BE17A00B8F155 /* ReactNativeConfig.h */; };
@@ -56,6 +57,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		07BF4DBB2476FBED00E59829 /* ReactNativeConfigModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReactNativeConfigModule.h; sourceTree = "<group>"; };
+		07BF4DBC2476FBED00E59829 /* ReactNativeConfigModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReactNativeConfigModule.m; sourceTree = "<group>"; };
 		3DF7F6AC203AA09B00D0EAB7 /* libReactNativeConfig-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libReactNativeConfig-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		50406729228CAD5A00E0438A /* ReadDotEnv.rb */ = {isa = PBXFileReference; lastKnownFileType = text.script.ruby; path = ReadDotEnv.rb; sourceTree = "<group>"; };
 		50830C45228DD3D000CEA8FC /* BuildXCConfig.rb */ = {isa = PBXFileReference; lastKnownFileType = text.script.ruby; path = BuildXCConfig.rb; sourceTree = "<group>"; };
@@ -106,6 +109,8 @@
 				50830C45228DD3D000CEA8FC /* BuildXCConfig.rb */,
 				EB2648E21C7BE17A00B8F155 /* ReactNativeConfig.h */,
 				EBE4E8461C7D2456000F8875 /* ReactNativeConfig.m */,
+				07BF4DBB2476FBED00E59829 /* ReactNativeConfigModule.h */,
+				07BF4DBC2476FBED00E59829 /* ReactNativeConfigModule.m */,
 				EBE4E8291C7BF6DD000F8875 /* BuildDotenvConfig.rb */,
 				50406729228CAD5A00E0438A /* ReadDotEnv.rb */,
 			);
@@ -234,6 +239,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07BF4DBD2476FBED00E59829 /* ReactNativeConfigModule.m in Sources */,
 				EBE4E8471C7D2456000F8875 /* ReactNativeConfig.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/ReactNativeConfig/ReactNativeConfig.h
+++ b/ios/ReactNativeConfig/ReactNativeConfig.h
@@ -1,11 +1,6 @@
-#if __has_include(<React/RCTBridgeModule.h>)
-#import <React/RCTBridgeModule.h>
-#elif __has_include("React/RCTBridgeModule.h")
-#import "React/RCTBridgeModule.h"
-#else
-#import "RCTBridgeModule.h"
-#endif
-@interface ReactNativeConfig : NSObject <RCTBridgeModule>
+#import <Foundation/Foundation.h>
+
+@interface ReactNativeConfig : NSObject
 
 + (NSDictionary *)env;
 + (NSString *)envFor: (NSString *)key;

--- a/ios/ReactNativeConfig/ReactNativeConfig.m
+++ b/ios/ReactNativeConfig/ReactNativeConfig.m
@@ -3,13 +3,6 @@
 
 @implementation ReactNativeConfig
 
-RCT_EXPORT_MODULE()
-
-+ (BOOL)requiresMainQueueSetup
-{
-    return YES;
-}
-
 + (NSDictionary *)env {
     return (NSDictionary *)DOT_ENV;
 }
@@ -17,10 +10,6 @@ RCT_EXPORT_MODULE()
 + (NSString *)envFor: (NSString *)key {
     NSString *value = (NSString *)[self.env objectForKey:key];
     return value;
-}
-
-- (NSDictionary *)constantsToExport {
-    return DOT_ENV
 }
 
 @end

--- a/ios/ReactNativeConfig/ReactNativeConfigModule.h
+++ b/ios/ReactNativeConfig/ReactNativeConfigModule.h
@@ -1,0 +1,14 @@
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#elif __has_include("React/RCTBridgeModule.h")
+#import "React/RCTBridgeModule.h"
+#else
+#import "RCTBridgeModule.h"
+#endif
+
+@interface ReactNativeConfigModule : NSObject <RCTBridgeModule>
+
++ (NSDictionary *)env;
++ (NSString *)envFor: (NSString *)key;
+
+@end

--- a/ios/ReactNativeConfig/ReactNativeConfigModule.m
+++ b/ios/ReactNativeConfig/ReactNativeConfigModule.m
@@ -1,0 +1,25 @@
+#import "ReactNativeConfig.h"
+#import "ReactNativeConfigModule.h"
+
+@implementation ReactNativeConfigModule
+
+RCT_EXPORT_MODULE()
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
++ (NSDictionary *)env {
+    return ReactNativeConfig.env;
+}
+
++ (NSString *)envFor: (NSString *)key {
+    return [ReactNativeConfig envFor:key];
+}
+
+- (NSDictionary *)constantsToExport {
+    return ReactNativeConfig.env;
+}
+
+@end


### PR DESCRIPTION
I've split a module for two interfaces that allowed to use config service without the `react` dependency.
That will helps to use a module in an ios app extensions.