### PR TITLE
Fixed regenerating config on each build

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -25,8 +25,7 @@ HOST_PATH="$SRCROOT/../.."
 "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
 ),
     execution_position: :before_compile,
-    input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb'],
-    output_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']
+    input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb']
   }
 
   s.source_files = 'ios/**/*.{h,m}'


### PR DESCRIPTION
When output file already exist, the script is not ran, even when configuration has changed. This causes a bug when using ```react-native run-ios --scheme <scheme>``` with different configurations for different schemes, resulting in having old configuration in the ```Config``` object, while environment variables are set properly.

Cleaning build folder (or derived data) manually before build with changed configuration fixes this problem, but also causes a rebuild of all dependencies which may be much longer, depending on the size of the project (and obviously is error prone).

When the ```output_files``` section of the script does not contain path to the generated file, it is recreated for every build, thus forcing the pod to rebuild, and results in having a proper config, while extending the build time imperceptibly.