### PR TITLE
Fix deprecation with gradle 4.0.1

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -80,7 +80,7 @@ tasks.whenTaskAdded { task ->
             if (task.name.toLowerCase() == "generate"+envConfigName+"buildconfig") {
                 task.doFirst() {
                     android.applicationVariants.all { variant ->
-                        def variantConfigString = variant.getVariantData().getVariantConfiguration().getFullName()
+                        def variantConfigString = variant.getVariantData().getName()
                         if (envConfigName.contains(variantConfigString.toLowerCase())) {
                             loadDotEnv(envConfigName)
                             project.env.each { k, v ->


### PR DESCRIPTION
fix " No signature of method: com.android.build.gradle.internal.variant.ApplicationVariantData.getVariantConfiguration() is applicable for argument types: () values: []" with gradle 4.0.1