### PR TITLE
Fix named import

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,4 +5,5 @@
 // iOS: config vars set in xcconfig and exposed via ReactNativeConfig.m
 import { NativeModules } from 'react-native';
 
-export default NativeModules.ReactNativeConfigModule || {};
+export const Config = NativeModules.ReactNativeConfigModule || {}
+export default Config;


### PR DESCRIPTION
### This PR attempts to fix the following issue:

The types definition (`index.d.ts`) explicitly says that the library can be used with a default import or a named import:
```
import Config from "react-native-config";
import { Config } from "react-native-config";
```
However, in the `index.js` file there's no named export, only the default export is available

cc. @pedro @luancurti 