### PR TITLE
Add subspec for iOS extensions without React

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 xcuserdata
 xcshareddata
+/.idea/

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ target 'ShareExtension' do
   platform :ios, '9.0'
 
   pod 'react-native-config', :path => '../node_modules/react-native-config'
+
+  # For extensions without React dependencies
+  pod 'react-native-config/Extension', :path => '../node_modules/react-native-config'
 end
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-config",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Expose config variables to React Native apps",
   "keywords": [
     "env",

--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -28,8 +28,17 @@ HOST_PATH="$SRCROOT/../.."
     input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb']
   }
 
-  s.source_files = 'ios/**/*.{h,m}'
   s.requires_arc = true
+  s.default_subspec = 'App'
 
-  s.dependency 'React'
+    s.subspec 'App' do |app|
+    app.source_files = 'ios/**/*.{h,m}'
+    app.dependency 'React'
+  end
+
+  s.subspec 'Extension' do |ext|
+    # Use this subspec for iOS extensions that cannot use React dependency
+    ext.source_files = ['ios/**/ReactNativeConfig.{h,m}', 'ios/**/GeneratedDotEnv.m']
+  end
+
 end

--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -36,8 +36,19 @@ HOST_PATH="$SRCROOT/../.."
     app.dependency 'React'
   end
 
+  # Use this subspec for iOS extensions that cannot use React dependency
   s.subspec 'Extension' do |ext|
-    # Use this subspec for iOS extensions that cannot use React dependency
+    # Had to duplicate the script_phase since it wasn't being passed down. Not sure why
+    ext.script_phase = {
+      name: 'Config codegen',
+      script: %(
+        set -ex
+        HOST_PATH="$SRCROOT/../.."
+        "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
+        ),
+      execution_position: :before_compile,
+      input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb']
+    }
     ext.source_files = ['ios/**/ReactNativeConfig.{h,m}', 'ios/**/GeneratedDotEnv.m']
   end
 


### PR DESCRIPTION
The current podspec lists `React` as a dependency. This causes `RCTLinking` to be built (among other deps).

This can be problematic when working on an iOS 14 Widget that needs to share config variables since WidgetKit, and other extensions, do not allow certain functionality used in `RCTLinking`.

Separating into subspecs gives the consumer of `react-native-config` the option to pick what dependencies are built by their pod target