### PR TITLE
Don't specify buildToolsVersion on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,6 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion


### PR DESCRIPTION
We're depending on a version of the Android Gradle plugin higher than 3, so we don't need to specify a buildToolsVersion. Trying to grab this value from the root project, in a project that also doesn't specify it, would fail. Since the only reason we were doing the fetch was to specify our own buildToolsVersion, I think we can safely remove it.