### PR TITLE
Change the trigger for the Windows CI

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,5 +1,5 @@
 name: Windows CI
-on: [watch]
+on: [pull_request]
 
 jobs:
   run-windows-tests:


### PR DESCRIPTION
By mistake, I've left the `on: [watch]` int the workflow .yml file. I used that when developing, to trigger the CI run every time I've stared the repo.

This fixes this by changing it to `on: [pull_request]` which will correctly make the CI run on each new PR.