### PR TITLE
Fix for gradle 4.1.0.

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.2")
+        classpath 'com.android.tools.build:gradle:4.1.0-rc03'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:4.1.0-rc03'
     }
 }
 

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -80,7 +80,7 @@ tasks.whenTaskAdded { task ->
             if (task.name.toLowerCase() == "generate"+envConfigName+"buildconfig") {
                 task.doFirst() {
                     android.applicationVariants.all { variant ->
-                        def variantConfigString = variant.getVariantData().getName()
+                        def variantConfigString = variant.getName()
                         if (envConfigName.contains(variantConfigString.toLowerCase())) {
                             loadDotEnv(envConfigName)
                             project.env.each { k, v ->


### PR DESCRIPTION
In gradle 4.1.0 the syntax has changed for getting the variant name.
I'm not sure how gradle supports using different gradle plugins in the app-project vs library.