### PR TITLE
docs: escape cp for PROJECT_DIR with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Then edit the newly created scheme to make it use a different env file. From the
 - Click "Pre-actions", and under the plus sign select "New Run Script Action"
 - Where it says "Type a script or drag a script file", type:
   ```
-  cp ${PROJECT_DIR}/../.env.staging ${PROJECT_DIR}/../.env  # replace .env.staging for your file
+  cp "${PROJECT_DIR}/../.env.staging" "${PROJECT_DIR}/../.env"  # replace .env.staging for your file
   ```
 Also ensure that "Provide build settings from", just above the script, has a value selected so that PROJECT_DIR is set.
 


### PR DESCRIPTION
Small update to the doc to take into account that `PROJECT_DIR` may contain spaces and should be "escaped" so that the cp works in those cases.

I had the issue on my project where it worked well locally and failed in the CI because the CI had a space in PROJECT_DIR.

Since like me most people will copy paste the `cp` line from the readme it's worthwhile updating it so less people get this issue