### PR TITLE
add important caveat for android gradle env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ project.ext.envConfigFiles = [
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 ```
 
+Also note that besides requiring lowercase, the matching is done with `buildFlavor.startsWith`, so a build named `debugProd` could match the `debug` case, above.
+
 <a name="ios-multi-scheme"></a>
 
 #### iOS


### PR DESCRIPTION
The way matching is done can lead to unexpected results that can be difficult to troubleshoot.

I found this out the hard way with my own `debugProd` build variant alongside a `debug` one...