### PR TITLE
Fail iOS builds on malformed .env files, add troubleshooting instruct…

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ If using Dexguard, the shrinking phase will remove resources it thinks are unuse
 
     -keepresources string/build_config_package
 
+### TypeError: _reactNativeConfig.default.getConstants is not a function
+
+This error stems from `.env` file being malformed. Accepted formats are listed here https://regex101.com/r/cbm5Tp/1. Common causes are:
+  - Missing the .env file entirely
+  - Rogue space anywhere, example: in front of env variable: ` MY_ENV='foo'`
+
 ## Testing
 
 Since `react-native-config` contains native code, it cannot be run in a node.js environment (Jest, Mocha). [react-native-config-node](https://github.com/CureApp/react-native-config-node) provides a way to mock `react-native-config` for use in test runners - exactly as it is used in the actual app.

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -48,7 +48,9 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
 
     if (f.exists()) {
         f.eachLine { line ->
+            // https://regex101.com/r/cbm5Tp/1
             def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)
+            // TODO: Fail Android builds if line doesn't match
             if (matcher.getCount() == 1 && matcher[0].size() == 3) {
                 env.put(matcher[0][1], matcher[0][2].replace('"', '\\"'))
             }

--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -40,7 +40,8 @@ def read_dot_env(envs_root)
 
     raw.split("\n").inject({}) do |h, line|
       m = line.match(dotenv_pattern)
-      next h if m.nil?
+      if m.nil?
+        abort('Invalid entry in .env file. Please verify your .env file is correctly formatted.')
 
       key = m[:key]
       # Ensure string (in case of empty value) and escape any quotes present in the value.


### PR DESCRIPTION
Invalid format of a `.env` file creates an error that is very difficult to debug and is not documented anywhere. The error that is outputted in console for when `.env` file is missing or is malformed is as follows:

```
[Thu Oct 29 2020 20:29:26.372] ERROR TypeError: _reactNativeConfig.default.getConstants  is not a function. (In '_reactNativeConfig.default.getConstants()'), '_reactNativeConfig.default.getConstants' is undefined)
[Thu Oct 29 2020 20:29:27.450] ERROR Invariant Violation: Module AppRegistry is not a registered callable module (calling runApplication)
```

The error message doesn't make sense and is very hard to debug (unless you have experienced it once before ;) )

This PR aims to abort the iOS build when the `.env` file is not correctly malformed, adds troubleshooting steps in the README.md

Closes https://github.com/luggit/react-native-config/issues/495