### PR TITLE
Ignore empty lines and comments in env files

### DIFF
--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -41,6 +41,9 @@ def read_dot_env(envs_root)
     raw.split("\n").inject({}) do |h, line|
       m = line.match(dotenv_pattern)
 
+      next h if line.nil? || line.strip.empty?
+      next h if line.match(/^\s*#/)
+
       if m.nil?
         abort('Invalid entry in .env file. Please verify your .env file is correctly formatted.')
       end


### PR DESCRIPTION
As noted in #522, .env files with blank lines or comments are no longer being ignored. This PR updates that. HTH!