### PR TITLE
Add an instruction to configure different envfiles per build settings using Podfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,48 @@ Then edit the newly created scheme to make it use a different env file. From the
   ```
 Also ensure that "Provide build settings from", just above the script, has a value selected so that PROJECT_DIR is set.
 
+Alternatively, if you have separated build configurations, you may easily set the different envfiles per configuration by adding these lines into the end of Podfile:
+
+```ruby
+ENVFILES = {
+  'Debug' => '$(PODS_ROOT)/../../.env.debug',
+  'Release' => '$(PODS_ROOT)/../../.env.production',
+}
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      if target.name == 'react-native-config'
+        config.build_settings['ENVFILE'] = ENVFILES[config.name]
+      end
+    end
+  end
+end
+```
+
+Note that if you have flipper enabled in your Podfile, you must move the `flipper_post_install` into the newely added hook since Podfile doesn't allow multiple `post_install` hooks.
+
+```diff
+  target 'MyApp' do
+    # ...
+    use_flipper!
+-   post_install do |installer|
+-     flipper_post_install(installer)
+-   end
+  end
+
+  post_install do |installer|
++   flipper_post_install(installer)
+
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        if target.name == 'react-native-config'
+          config.build_settings['ENVFILE'] = ENVFILES[config.name]
+        end
+      end
+    end
+  end
+```
+
 ## Troubleshooting
 
 ### Problems with Proguard


### PR DESCRIPTION
This library generates code using [Ruby script `ReadDotEnv.rb`](https://github.com/luggit/react-native-config/blob/v1.4.2/ios/ReactNativeConfig/ReadDotEnv.rb) which reads `ENVFILE` from the environment variables. The script is executed during the CocoaPods library build phase.

With [`pod_install` hook](https://guides.cocoapods.org/syntax/podfile.html#post_install) you can set custom build settings of CocoaPods libraries. Since Xcode exposes all build settings to the environment variables, this is the best place to set `ENVFILE`. You may also access to the build configurations so you can set different envfiles per build configurations.

### Example

(I'm using Debug, Development, Production build configurations)

<img width="1139" alt="Screen Shot 2021-01-26 at 6 14 12 PM" src="https://user-images.githubusercontent.com/931655/105830170-84443700-6008-11eb-8f20-7b71d4f11b25.png">

### Related issues

- #281
