### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ defaultConfig {
 }
 ```
 
+In your build variant, you may also want to specify [`matchingFallbacks`](https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/BuildType#matchingfallbacks) (and set it to `['debug']` or `['release']`) in order to specify the appropriate build variant to  3rd-party react native android modules (including this one) you may be using e.g.:
+
+```
+    buildTypes {
+        debug {...}
+        release {...}
+	
+        foo.initWith(buildTypes.debug)
+        foo {
+            applicationIdSuffix ".foo"
+            matchingFallbacks =  ['debug']
+        }
+```
+
 ## Native Usage
 
 ### Android


### PR DESCRIPTION
When setting up react-native-config, I realised I needed to create multiple build variants for android. However, I kept running into this problem with Gradle builds:

```
   > Could not resolve project :react-native-config.
     Required by:
         project :app
      > No matching variant of project :react-native-config was found. The consumer was configured to find an API of a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'foo' but:
          - Variant 'debugApiElements' capability Topic:react-native-config:unspecified declares an API of a component:
              - Incompatible because this component declares a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'debug' and the consumer needed a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'foo'
          - Variant 'debugRuntimeElements' capability Topic:react-native-config:unspecified declares a runtime of a component:
              - Incompatible because this component declares a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'debug' and the consumer needed a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'foo'
          - Variant 'releaseApiElements' capability Topic:react-native-config:unspecified declares an API of a component:
              - Incompatible because this component declares a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release' and the consumer needed a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'foo'
          - Variant 'releaseRuntimeElements' capability Topic:react-native-config:unspecified declares a runtime of a component:
              - Incompatible because this component declares a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'release' and the consumer needed a component, as well as attribute 'com.android.build.api.attributes.BuildTypeAttr' with value 'foo'

```

A solution was hard to find, but very easy to apply. In my opinion it's quite relevant to someone setting up react-native-config.