### PR TITLE
Add support for overriding env file variables with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,39 @@ Then edit the newly created scheme to make it use a different env file. From the
   ```
 Also ensure that "Provide build settings from", just above the script, has a value selected so that PROJECT_DIR is set.
 
+## Overriding Variables (iOS & Android)
+
+Environment variables can override or be added alongside variables declared in `.env`:
+
+For an `.env` in the root of your React Native app:
+
+```
+API_URL=https://myapi.com
+GOOGLE_MAPS_API_KEY=abcdefgh
+TRACKING_ENABLED=true
+```
+
+By running your app with `RN_CONFIG_TRACKING_ENABLED=false react-native run-ios`, the variables declared in your app will be:
+
+```
+import Config from "react-native-config";
+
+Config.API_URL; // 'https://myapi.com'
+Config.GOOGLE_MAPS_API_KEY; // 'abcdefgh'
+Config.TRACKING_ENABLED; // 'false'
+```
+
+Any environment variables with an `RN_CONFIG_` prefix will be available. For instance, we could add a new variable by running `RN_CONFIG_DEV_TOOLS=true react-native run-ios` with the same `.env` file above will result in:
+
+```
+import Config from "react-native-config";
+
+Config.API_URL; // 'https://myapi.com'
+Config.GOOGLE_MAPS_API_KEY; // 'abcdefgh'
+Config.TRACKING_ENABLED; // 'true'
+Config.DEV_TOOLS; // 'true'
+```
+
 ## Troubleshooting
 
 ### Problems with Proguard

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -61,6 +61,11 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
         println("**************************")
     }
 
+    System.env
+        .findAll { it.key.startsWith("RN_CONFIG_") }
+        .collectEntries { key, value -> [key.substring(10), value] }
+        .each { key, value -> env.put(key, value) }
+
     project.ext.set("env", env)
 }
 

--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -59,5 +59,11 @@ def read_dot_env(envs_root)
       puts('**************************')
       return [{}, false] # set dotenv as an empty hash
   end
+
+  ENV
+    .select { |k,v| k.start_with?("RN_CONFIG_") }
+    .transform_keys { |k| k[10..] }
+    .each { |k,v| dotenv[k]=v }
+
   [dotenv, custom_env]
 end


### PR DESCRIPTION
## Background

In my project, I have a need to make one-off configuration changes on occasion. This could be to change a configuration for automation builds, for instance, where we don't want a special `.env.auto` that's 99% identical to our `.env` and only creates a maintenance burden.

## Inspiration

What I am proposing in this PR is inspired by Gradle, and the ability there to override Gradle project properties with environment variables. [See here for more information.](https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties)

Instead of relying on `ORG_GRADLE_PROJECT_` as the prefix, this PR instead proposes a `RN_CONFIG_` prefix.

## Implementation

In both the iOS and Android build scripts, I have added a new section for reading the environment variables on the system and applying them to the existing environment config. This section lives outside of the reading/parsing of the env file, so in the event that there is no env file found, the `RN_CONFIG_` environment variables will still be applied and passed to the application.

I have not done anything for Windows yet; I do not have a means to test it. Any help here is appreciated.

---

I understand if this is outside the scope of this project, but it felt like a natural extension to the library. Please let me know if you have any questions, or want to see anything changed!