### PR TITLE
Change xml style to mention package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Add this in `android/app/build.gradle`
 ```
 defaultConfig {
     ...
-    resValue "string", "build_config_package", "YOUR_PACKAGE_NAME_IN_ANDROIDMANIFEST.XML"
+    resValue "string", "build_config_package", "YOUR_PACKAGE_NAME_IN_ANDROIDMANIFEST_XML"
 }
 ```
 


### PR DESCRIPTION
I miss read to use `app-id.XML` for default config.
How about to change `YOUR_PACKAGE_NAME_IN_ANDROIDMANIFEST.XML` to `YOUR_PACKAGE_NAME_IN_ANDROIDMANIFEST_XML`.

Related comment:
https://github.com/luggit/react-native-config/issues/170#issuecomment-796733674