### PR TITLE
Fix not detecting custom envfile in /tmp/envfile

### DIFF
--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -14,7 +14,7 @@ def read_dot_env(envs_root)
   # pick a custom env file if set
   if File.exist?('/tmp/envfile')
     custom_env = true
-    file = File.read('/tmp/envfile').strip
+    file = '/tmp/envfile'
   else
     custom_env = false
     file = ENV['ENVFILE'] || defaultEnvFile


### PR DESCRIPTION
Fixes issue where if an envfile was available in /tmp/envfile it was incorrectly being File.read'd causing the begin block to throw and thus return an empty object to ReadDotEnv.rb

I gather this fixes a decent number of issues for instance #511 #594 and no doubt a few others.

Note: I'm not a ruby coder!