### PR TITLE
Get rid of useless? .env file name cache

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.rb
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.rb
@@ -12,7 +12,7 @@ puts "reading env file from #{envs_root} and writing .m to #{m_output_path}"
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
-dotenv, custom_env = read_dot_env(envs_root)
+dotenv = read_dot_env(envs_root)
 puts "read dotenv #{dotenv}"
 
 # create obj file that sets DOT_ENV as a NSDictionary

--- a/ios/ReactNativeConfig/BuildXCConfig.rb
+++ b/ios/ReactNativeConfig/BuildXCConfig.rb
@@ -7,7 +7,7 @@ envs_root = ARGV[0]
 config_output = ARGV[1]
 puts "reading env file from #{envs_root} and writing .config to #{config_output}"
 
-dotenv, custom_env = read_dot_env(envs_root)
+dotenv = read_dot_env(envs_root)
 
 dotenv_xcconfig = dotenv.map { |k, v| %(#{k}=#{v.gsub(/\/\//, "/$()/")}) }.join("\n")
 File.open(config_output, 'w') { |f| f.puts dotenv_xcconfig }

--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -11,14 +11,7 @@ def read_dot_env(envs_root)
   defaultEnvFile = '.env'
   puts "going to read env file from root folder #{envs_root}"
 
-  # pick a custom env file if set
-  if File.exist?('/tmp/envfile')
-    custom_env = true
-    file = File.read('/tmp/envfile').strip
-  else
-    custom_env = false
-    file = ENV['ENVFILE'] || defaultEnvFile
-  end
+  file = ENV['ENVFILE'] || defaultEnvFile
 
   dotenv = begin
     # https://regex101.com/r/cbm5Tp/1
@@ -59,5 +52,6 @@ def read_dot_env(envs_root)
       puts('**************************')
       return [{}, false] # set dotenv as an empty hash
   end
-  [dotenv, custom_env]
+
+  dotenv
 end


### PR DESCRIPTION
I may be missing something, but I don't see the point of caching the name of the env file or even to cache it in /tmp because it's shared with every other project where react-native-config might be used and may lead to conflicts.

In my case I've got 2 different projects both using `react-native-config`, the first one uses 3 different environments and we have 3 different .env (.env.dev, .env.staging, .env.production) and the second one just uses the default .env file. 
Because of the library caching the name of the file, I just can't switch from one project to the other without cleaning `/tmp/envfile` first because i'll end up with empty generated environments.

As far as I can tell, even if the `ReadDotEnv` script returns that custom_env value, it isn't used anywhere. It seems to me that it makes sense to use whatever is set to ENVFILE or fallback to the default name instead.