### PR TITLE
Fix Android behaviour with Android Gradle Plugin >=4.2.0

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -80,16 +80,14 @@ tasks.whenTaskAdded { task ->
     if (project.hasProperty("envConfigFiles")) {
         project.envConfigFiles.each { envConfigName, envConfigFile ->
             if (task.name.toLowerCase() == "generate"+envConfigName+"buildconfig") {
-                task.doFirst() {
-                    android.applicationVariants.all { variant ->
-                        def variantConfigString = variant.getName()
-                        if (envConfigName.contains(variantConfigString.toLowerCase())) {
-                            loadDotEnv(envConfigName)
-                            project.env.each { k, v ->
-                                def escaped = v.replaceAll("%","\\\\u0025")
-                                variant.buildConfigField "String", k, "\"$v\""
-                                variant.resValue "string", k, "\"$escaped\""
-                            }
+                android.applicationVariants.all { variant ->
+                    def variantConfigString = variant.getName()
+                    if (envConfigName.contains(variantConfigString.toLowerCase())) {
+                        loadDotEnv(envConfigName)
+                        project.env.each { k, v ->
+                            def escaped = v.replaceAll("%","\\\\u0025")
+                            variant.buildConfigField "String", k, "\"$v\""
+                            variant.resValue "string", k, "\"$escaped\""
                         }
                     }
                 }


### PR DESCRIPTION
React Native 0.65 upgraded the Android Gradle Plugin to 4.2.1, which causes anything using `react-native-config` to fail with the following error:

```
The value for property 'buildConfigFields' is final and cannot be changed any further.
```

Gradle has multiple phases: https://docs.gradle.org/current/userguide/build_lifecycle.html. The reason for this error is that Gradle executes the contents of `task.doFirst` during the **execution** phase. However, during **execution** then `buildConfigFields` is `final` so cannot be modified. It can only be modified during the **configure** phase.

This PR removes the `task.doFirst` callback, and simply executes the code inside the callback immediately during the **configure** phase. This has been tested by myself and some other users (see #567) and still works with multiple build types and multiple flavors, both with gradle plugin `4.1.x` and `4.2.x`.

My assumption as to why this upgrade broke `react-native-config` is that Gradle decided to strictly enforce that `buildConfigFields` is `final` during the **execution** phase, whereas in previous versions it probably wasn't enforced but should have been. Google are aware of this change in behaviour (https://issuetracker.google.com/issues/172657565) and closed the issue with a **Won't fix (intended behaviour)** response. So it's up to `react-native-config` to change to be compatible with this new behaviour.

Fixes #567
Fixes #578
Fixes #608