### PR TITLE
Used correct heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ std::string api_key = ReactNativeConfig::API_KEY;
 
 Similarly, you can access those values in other project by adding reference to the `RNCConfig` as described in the manual linking section.
 
-#### Availability in Build settings and Info.plist
+### Availability in Build settings and Info.plist
 
 With one extra step environment values can be exposed to "Info.plist" and Build settings in the native project.
 


### PR DESCRIPTION
I think this part was incorrectly highlighted making it look like that part is under the `windows` portion which is confusing.