### PR TITLE
fix(ios): keep leading whitespace in XCConfig

### DIFF
--- a/ios/ReactNativeConfig/BuildXCConfig.rb
+++ b/ios/ReactNativeConfig/BuildXCConfig.rb
@@ -9,5 +9,5 @@ puts "reading env file from #{envs_root} and writing .config to #{config_output}
 
 dotenv, custom_env = read_dot_env(envs_root)
 
-dotenv_xcconfig = dotenv.map { |k, v| %(#{k}=#{v.gsub(/\/\//, "/$()/")}) }.join("\n")
+dotenv_xcconfig = dotenv.map { |k, v| %(#{k}=$()#{v.gsub(/\/\//, "/$()/")}) }.join("\n")
 File.open(config_output, 'w') { |f| f.puts dotenv_xcconfig }


### PR DESCRIPTION
If we use quotes (`'"`) in .env file, which means we wants to keep leading whitespaces, that's also what we done in ReadDotEnv.rb

But in XCConfig, any leading whitespace will be ignored unless we has something like `$()` in front these whitespaces.

This PR inserts `$()` to the front of each value.