### PR TITLE
Fix msbuild

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: '12.9.1'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.1
       with:
         vs-version: 16.5
 


### PR DESCRIPTION
GitHub deprecated ::add-path and since microsoft/setup-msbuild has been fixed (v1.1)