### PR TITLE
Update react-native-config.podspec

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -49,6 +49,7 @@ HOST_PATH="$SRCROOT/../.."
         ),
       execution_position: :before_compile,
       input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb']
+      output_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']
     }
     ext.source_files = ['ios/**/ReactNativeConfig.{h,m}', 'ios/**/GeneratedDotEnv.m']
   end


### PR DESCRIPTION
Real fix for indicating we have generated output file.

Required for AppCenter and other build systems.