### PR TITLE
[FIX] - Documentation readme import lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ if cocoapods are used in the project then pod has to be installed as well:
 	protected List<ReactPackage> getPackages() {
 		   return Arrays.asList(
            		new MainReactPackage()
-	+      		new ReactNativeConfigPackage()
+	+      		new RNCConfigPackage()
 	    );
 	}
 	```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ if cocoapods are used in the project then pod has to be installed as well:
 	**MainApplication.java**
 	
 	```diff
-	+ import com.lugg.ReactNativeConfig.ReactNativeConfigPackage;
+	+ import com.lugg.RNCConfig.RNCConfigPackage;
 	
 	@Override
 	protected List<ReactPackage> getPackages() {


### PR DESCRIPTION

Before [this release](https://github.com/luggit/react-native-config/releases/tag/v1.5.0) the files were renamed from`ReactNativeConfig.ReactNativeConfigPackage` to `RNCConfig.RNCConfigPackage`.


Generating the error:

```
Note: Recompile with -Xlint:deprecation for details.
/Users/marcelxsilva/Documents/projects/<NAME PROJECT>/android/app/src/main/java/com/<NAME PROJECT>/app/MainApplication.java:10: error: package com.lugg.ReactNativeConfig does not exist
import com.lugg.ReactNativeConfig.ReactNativeConfigPackage;

```


Basically update the readme to the correct import, after change builded with success.


