### PR TITLE
Added TypeScript section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,10 @@ export default {
 };
 ```
 
+## TypeScript
+
+To automatically generate types declaration for `.env` files, you can use community libraries such as [react-native-config-codegen](https://github.com/jackstudd/react-native-config-codegen).
+
 ## Meta
 
 Created by Pedro Belo at [Lugg](https://lugg.com/).


### PR DESCRIPTION
I made for myself a small CLI to auto generate the TS for my .env files, I made it public and thought to add it in the docs since there's no mention of TS