### PR TITLE
Add GeneratedDotEnv.m as an output file

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -26,7 +26,7 @@ HOST_PATH="$SRCROOT/../.."
 ),
     execution_position: :before_compile,
     input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb'],
-    output_files: ['$BUILD_DIR/GeneratedInfoPlistDotEnv.h']
+    output_files: ['$BUILD_DIR/GeneratedInfoPlistDotEnv.h', '$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']
   }
 
   s.requires_arc = true


### PR DESCRIPTION
### Why

Locally I can build my app just fine, but when I do:

```
rm -rf node_modules && yarn install && yarn ios-install # (cocoapods)
```

the subsequent builds fail, and the only way they succeed again is if I clear the DerivedData folder before building.

This is the output when I build after nuking my node_modules folder:

```
The following build commands failed:
        CompileC /Users/abejfehr/Library/Developer/Xcode/DerivedData/MyApp-abcd1234/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/react-native-config.build/Objects-normal/x86_64/ReactNativeConfig.o /Users/abejfehr/my-app/node_modules/react-native-config/ios/ReactNativeConfig/ReactNativeConfig.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'react-native-config' from project 'Pods')
```

So this actually makes sense — the ruby script to produce GeneratedDotEnv.m doesn't get re-ran because its inputs/outputs didn't change, but that's because GeneratedDotEnv.m isn't part of the inputs or outputs.

### What

This PR adds the GeneratedDotEnv.m to the outputs of the build script that produces it, so that it gets regenerated when necessary.