### PR TITLE
feat: add support for Android specific envs

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -52,7 +52,8 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
             def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)
             // TODO: Fail Android builds if line doesn't match
             if (matcher.getCount() == 1 && matcher[0].size() == 3) {
-                env.put(matcher[0][1], matcher[0][2].replace('"', '\\"'))
+                def key = matcher[0][1].replaceAll(/^ANDROID_/, '')
+                env.put(key, matcher[0][2].replace('"', '\\"'))
             }
         }
     } else {


### PR DESCRIPTION
Variables whose key start with `ANDROID_` are rewritten without the platform prefix