### PR TITLE
feat: add support for iOS specific envs

### DIFF
--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -48,7 +48,7 @@ def read_dot_env(envs_root)
         abort('Invalid entry in .env file. Please verify your .env file is correctly formatted.')
       end
 
-      key = m[:key]
+      key = m[:key].sub(/^IOS_/, '')
       # Ensure string (in case of empty value) and escape any quotes present in the value.
       val = m[:val].to_s.gsub('"', '\"')
       h.merge(key => val)


### PR DESCRIPTION
Variables whose key start with `IOS_` are rewritten without the platform prefix