### PR TITLE
add defaultEnvExample on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ $ cd android && export ENVFILE=.env.staging ./gradlew bundleRelease
 Alternatively, you can define a map in `build.gradle` associating builds with env files. Do it before the `apply from` call, and use build cases in lowercase, like:
 
 ```
+project.ext.defaultEnvFile = ".env.development"
 project.ext.envConfigFiles = [
     debug: ".env.development",
     release: ".env.production",


### PR DESCRIPTION
add example for user to setup the default env to prevent this error

![image](https://github.com/luggit/react-native-config/assets/36694324/109d5643-2371-4b93-9e05-844899ca69f6)
