### PR TITLE
fix(iOS): #698 Re-generate env file on each build

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -19,11 +19,16 @@ Pod::Spec.new do |s|
   s.source       = { git: 'https://github.com/luggit/react-native-config.git', tag: "v#{s.version.to_s}" }
   s.script_phase = {
     name: 'Config codegen',
-    script: %(
-set -ex
-HOST_PATH="$SRCROOT/../.."
-"${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
-),
+    script: '
+    #!/bin/bash
+
+    # We have to touch the file because otherwise Xcode will not detect the change and will not re-run the script (https://github.com/luggit/react-native-config/issues/698)
+    touch "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb"
+        
+    set -ex
+    HOST_PATH="$SRCROOT/../.."
+    "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
+    ',
     execution_position: :before_compile,
     input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb'],
     output_files: ['$BUILD_DIR/GeneratedInfoPlistDotEnv.h', '$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']


### PR DESCRIPTION
This is a fix for #698.

Updated the **podspec**'s `before_compile` script to `touch` the **BuildDotenvConfig.rb** file so that Xcode/xcodebuild can pick up on the changes.