### PR TITLE
fix(android): add support new arch 0.81 android codegen issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,14 @@ buildscript {
     }
 }
 
+def isNewArchitectureEnabled() {
+  return project.hasProperty("newArchEnabled") && (project.newArchEnabled == "true" || project.newArchEnabled == true)
+}
+
 apply plugin: 'com.android.library'
+if (isNewArchitectureEnabled()) {
+    apply plugin: 'com.facebook.react'
+}
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -44,10 +51,21 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+
+        ndk {
+            abiFilters(*reactNativeArchitectures())
+        }
     }
     lintOptions {
         abortOnError false
     }
+}
+
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
 repositories {

--- a/src/NativeRNCConfig.ts
+++ b/src/NativeRNCConfig.ts
@@ -4,7 +4,8 @@ import { TurboModuleRegistry } from 'react-native';
 export interface Spec extends TurboModule {
   // Synchronous getters (supported on Windows TurboModules)
   getAll(): { [key: string]: string };
-  get(key: string): string;
+  // it's overriding react-native method, so we're not using it
+  // get(key: string): string;
   // Optional Composition info hook
   compositionInfo?(): string;
 }


### PR DESCRIPTION
This is the minimal version for working in 0.81 android new arch.

- fix `CMakeList` issue by supporting `build.gradle` new arch configs
- fix `codegen` issue by removing redundant `get` keyword function

Tested by both iOS and Android 0.81.4 new arch

Maybe we can test this by `"react-native-config": "lugg/react-native-config#pull/854/head",` (as mentioned in https://github.com/lugg/react-native-config/pull/852#issuecomment-3368862509)